### PR TITLE
Replaced title with the name used for the repo and PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **This is a work in progress. It "works for me" at www.apiregistro.com.br, 
 but I cannot warranty that it fully "works everywhere" yet.**
 
-rest_framework_nested
+drf-nested-routers
 =====================
 
 This package provides routers and relations to create nested resources in the


### PR DESCRIPTION
I propose to change the title of the README.md to the name used for the repository itself and the name used in PyPi, which is drf-nested-routers.
