### PR TITLE
Prevent AttributeError even if pk_url_kwarg is given.

### DIFF
--- a/rest_framework_nested/relations.py
+++ b/rest_framework_nested/relations.py
@@ -158,6 +158,7 @@ class HyperlinkedIdentityField(Field):
 
     slug_field = 'slug'
     slug_url_kwarg = None  # Defaults to same as `slug_field` unless overridden
+    pk_url_kwarg = 'pk'
 
     def __init__(self, *args, **kwargs):
         try:


### PR DESCRIPTION
```python
>>> self.pk_url_kwarg = kwargs.pop('pk_url_kwarg', self.pk_url_kwarg)
AttributeError: 'HyperlinkedIdentityField' object has no attribute 'pk_url_kwarg'
```