### PR TITLE
Added NestedDefaultRouter that use Rest-Framework's DefaultRouter

### DIFF
--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -10,7 +10,9 @@ Example:
     router = routers.SimpleRouter()
     router.register(r'domains', DomainViewSet)
 
-    domains_router = routers.NestedSimpleRouter(router, r'domains', lookup='domain')
+    domains_router = routers.NestedSimpleRouter(router,
+                                                r'domains',
+                                                lookup='domain')
     domains_router.register(r'nameservers', NameserverViewSet)
 
     url_patterns = patterns('',
@@ -42,14 +44,17 @@ class SimpleRouter(rest_framework.routers.SimpleRouter):
         """
         base_regex = '(?P<{lookup_prefix}{lookup_field}>[^/]+)'
         lookup_field = getattr(viewset, 'lookup_field', 'pk')
-        return base_regex.format(lookup_field=lookup_field, lookup_prefix=lookup_prefix)
+        return base_regex.format(lookup_field=lookup_field,
+                                 lookup_prefix=lookup_prefix)
+
 
 class NestedSimpleRouter(SimpleRouter):
     def __init__(self, parent_router, parent_prefix, *args, **kwargs):
         self.parent_router = parent_router
         self.parent_prefix = parent_prefix
-        self.nest_count = getattr(parent_router, 'nest_count', 0) +1
-        self.nest_prefix = kwargs.pop('lookup', 'nested_%i' % self.nest_count) + '_'
+        self.nest_count = getattr(parent_router, 'nest_count', 0) + 1
+        self.nest_prefix = kwargs.pop('lookup',
+                                      'nested_%i' % self.nest_count) + '_'
         super(NestedSimpleRouter, self).__init__(*args, **kwargs)
 
         parent_registry = [registered for registered in self.parent_router.registry if registered[0] == self.parent_prefix]
@@ -60,7 +65,8 @@ class NestedSimpleRouter(SimpleRouter):
             raise RuntimeError('parent registered resource not found')
 
         nested_routes = []
-        parent_lookup_regex = parent_router.get_lookup_regex(parent_viewset, self.nest_prefix)
+        parent_lookup_regex = parent_router.get_lookup_regex(parent_viewset,
+                                                             self.nest_prefix)
         self.parent_regex = '{parent_prefix}/{parent_lookup_regex}/'.format(parent_prefix=parent_prefix, parent_lookup_regex=parent_lookup_regex)
         if hasattr(parent_router, 'parent_regex'):
             self.parent_regex = parent_router.parent_regex+self.parent_regex
@@ -68,9 +74,18 @@ class NestedSimpleRouter(SimpleRouter):
         for route in self.routes:
             route_contents = route._asdict()
 
-            route_contents['url'] = route.url.replace('^', '^'+self.parent_regex)
+            route_contents['url'] = route.url.replace('^',
+                                                      '^'+self.parent_regex)
             if 'mapping' not in route_contents:
                 route_contents['mapping'] = {}
             nested_routes.append(rest_framework.routers.Route(**route_contents))
 
         self.routes = nested_routes
+
+
+class DefaultRouter(rest_framework.routers.DefaultRouter, SimpleRouter):
+    pass
+
+
+class NestedDefaultRouter(DefaultRouter, NestedSimpleRouter):
+    pass


### PR DESCRIPTION
**DefaultRouter**
This router is similar to SimpleRouter as above, but additionally includes a default API root view, that returns a response containing hyperlinks to all the list views. It also generates routes for optional .json style format suffixes.
http://www.django-rest-framework.org/api-guide/routers#defaultrouter