### PR TITLE
Handle mapping error better than #25

### DIFF
--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -69,8 +69,6 @@ class NestedSimpleRouter(SimpleRouter):
             route_contents = route._asdict()
 
             route_contents['url'] = route.url.replace('^', '^'+self.parent_regex)
-            if 'mapping' not in route_contents:
-                route_contents['mapping'] = {}
-            nested_routes.append(rest_framework.routers.Route(**route_contents))
+            nested_routes.append(type(route)(**route_contents))
 
         self.routes = nested_routes


### PR DESCRIPTION
I looked at this briefly, and it seemed like basing the new route type on the original would be enough to avoid the mapping parameter error.
