### PR TITLE
Run tests using setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ class NameserverViewSet(viewsets.ViewSet):
         return Response(serializer.data)
 ```
 
+Contributing
+============
+
+Tests can be run through setup.py:
+
+```
+$ python setup.py test
+```
+
 License
 =======
 

--- a/rest_framework_nested/runtests/runtests.py
+++ b/rest_framework_nested/runtests/runtests.py
@@ -25,18 +25,10 @@ def usage():
     """
 
 
-def main():
+def main(test_case=''):
     TestRunner = get_runner(settings)
-    import ipdb;ipdb.set_trace()
 
     test_runner = TestRunner()
-    if len(sys.argv) == 2:
-        test_case = '.' + sys.argv[1]
-    elif len(sys.argv) == 1:
-        test_case = ''
-    else:
-        print(usage())
-        sys.exit(1)
     test_module_name = 'rest_framework_nested.tests'
     if django.VERSION[0] == 1 and django.VERSION[1] < 6:
         test_module_name = 'tests'
@@ -46,4 +38,10 @@ def main():
     sys.exit(failures)
 
 if __name__ == '__main__':
-    main()
+    if len(sys.argv) == 2:
+        main('.' + sys.argv[1])
+    elif len(sys.argv) == 1:
+        main()
+    else:
+        print(usage())
+        sys.exit(1)

--- a/rest_framework_nested/tests/test_hyperlinkedserializers.py
+++ b/rest_framework_nested/tests/test_hyperlinkedserializers.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 import json
 from django.test import TestCase
+from django.conf.urls import patterns, url
 from rest_framework import generics, status, serializers
-from rest_framework.compat import patterns, url
 from rest_framework.test import APIRequestFactory
 from rest_framework_nested.tests.models import (
     Anchor, BasicModel, ManyToManyModel, BlogPost, BlogPostComment,

--- a/rest_framework_nested/tests/test_relations_hyperlink.py
+++ b/rest_framework_nested/tests/test_relations_hyperlink.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from django.test import TestCase
+from django.conf.urls import patterns, url
 from rest_framework import serializers
-from rest_framework.compat import patterns, url
 from rest_framework.test import APIRequestFactory
 from rest_framework_nested.tests.models import (
     BlogPost,

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     install_requires=['djangorestframework'],
     setup_requires=['setuptools'],
     packages=find_packages(curdir),
-    tests_require=['djangorestframework<2.4', 'Django<1.7'],
+    tests_require=['Django<1.7'],
     cmdclass={'test': TestCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,29 @@
 #!/usr/bin/env python
 import os
+import sys
 
 from setuptools import find_packages, setup
+from setuptools.command.test import test
 
 curdir = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestCommand(test):
+    user_options = []
+
+    def initialize_options(self):
+        test.initialize_options(self)
+
+    def finalize_options(self):
+        test.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded
+        from rest_framework_nested.runtests import runtests
+        errno = runtests.main()
+        sys.exit(errno)
 
 setup(
     name='drf-nested-routers',
@@ -17,4 +37,6 @@ setup(
     install_requires=['djangorestframework'],
     setup_requires=['setuptools'],
     packages=find_packages(curdir),
+    tests_require=['djangorestframework<2.4', 'Django<1.7'],
+    cmdclass={'test': TestCommand},
 )


### PR DESCRIPTION
For a second I didn't think there were any tests... They're a little out of date, but running them doesn't need to be hard.

You can see in setup.py I pinned the Django and DRF versions... I'm leaving making it work with modern versions of the libraries as a task for the future.