### PR TITLE
Use appropriate type when recreating routes for nested_routes

### DIFF
--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -67,10 +67,13 @@ class NestedSimpleRouter(SimpleRouter):
 
         for route in self.routes:
             route_contents = route._asdict()
-
             route_contents['url'] = route.url.replace('^', '^'+self.parent_regex)
-            if 'mapping' not in route_contents:
-                route_contents['mapping'] = {}
-            nested_routes.append(rest_framework.routers.Route(**route_contents))
+
+            if(isinstance(route,rest_framework.routers.Route)):
+                nested_routes.append(rest_framework.routers.Route(**route_contents))
+            if(isinstance(route,rest_framework.routers.DynamicListRoute)):
+                nested_routes.append(rest_framework.routers.DynamicListRoute(**route_contents))
+            if(isinstance(route,rest_framework.routers.DynamicDetailRoute)):
+                nested_routes.append(rest_framework.routers.DynamicDetailRoute(**route_contents))
 
         self.routes = nested_routes


### PR DESCRIPTION
This commit to the rest framework adds new Route types. This takes that into account when rebuilding routes for the NestedSimpleRouter.

https://github.com/tomchristie/django-rest-framework/blob/ca7ba07b4e42bd1c7c6bb8088c0c5a2c434b56ee/rest_framework/routers.py
