### PR TITLE
Add support for lookup_value_regex

### DIFF
--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -30,21 +30,7 @@ from __future__ import unicode_literals
 import rest_framework.routers
 
 
-class SimpleRouter(rest_framework.routers.SimpleRouter):
-    """ Improvement of rest_framework.routers.SimpleRouter that allows the
-    lookup of urls of nested resources.
-
-    """
-    def get_lookup_regex(self, viewset, lookup_prefix=''):
-        """
-        Given a viewset, return the portion of URL regex that is used
-        to match against a single instance.
-        """
-        base_regex = '(?P<{lookup_prefix}{lookup_field}>[^/]+)'
-        lookup_field = getattr(viewset, 'lookup_field', 'pk')
-        return base_regex.format(lookup_field=lookup_field, lookup_prefix=lookup_prefix)
-
-class NestedSimpleRouter(SimpleRouter):
+class NestedSimpleRouter(rest_framework.routers.SimpleRouter):
     def __init__(self, parent_router, parent_prefix, *args, **kwargs):
         self.parent_router = parent_router
         self.parent_prefix = parent_prefix
@@ -62,6 +48,11 @@ class NestedSimpleRouter(SimpleRouter):
         nested_routes = []
         parent_lookup_regex = parent_router.get_lookup_regex(parent_viewset, self.nest_prefix)
         self.parent_regex = '{parent_prefix}/{parent_lookup_regex}/'.format(parent_prefix=parent_prefix, parent_lookup_regex=parent_lookup_regex)
+
+        # escape braces in parent_regex
+        # e.g., if it has lookup_value_regex = '[0-9a-f]{32}'
+        self.parent_regex = self.parent_regex.replace('{', '{{').replace('}', '}}')
+
         if hasattr(parent_router, 'parent_regex'):
             self.parent_regex = parent_router.parent_regex+self.parent_regex
 

--- a/rest_framework_nested/tests/test_routers.py
+++ b/rest_framework_nested/tests/test_routers.py
@@ -4,7 +4,8 @@ based upon https://github.com/alanjds/drf-nested-routers/issues/15
 from django.db import models
 from django.test import TestCase
 from rest_framework.viewsets import ModelViewSet
-from rest_framework_nested.routers import SimpleRouter, NestedSimpleRouter
+from rest_framework.routers import SimpleRouter
+from rest_framework_nested.routers import NestedSimpleRouter
 
 class A(models.Model):
     name=models.CharField(max_length=255)
@@ -24,6 +25,20 @@ class BViewSet(ModelViewSet):
 class CViewSet(ModelViewSet):
     model = C
 
+
+class AViewSetWithRegex(ModelViewSet):
+    model = A
+    lookup_value_regex = '[\d]{1,11}'
+
+class BViewSetWithRegex(ModelViewSet):
+    model = B
+    lookup_value_regex = '[\d]{1,11}'
+
+class CViewSetWithRegex(ModelViewSet):
+    model = C
+    lookup_value_regex = '[\d]{1,11}'
+
+
 class TestNestedSimpleRouter(TestCase):
     def setUp(self):
         self.router = SimpleRouter()
@@ -38,16 +53,44 @@ class TestNestedSimpleRouter(TestCase):
         urls = self.router.urls
         self.assertEquals(len(urls), 2)
         self.assertEquals(urls[0].regex.pattern, u'^a/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<pk>[^/]+)/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<pk>[^/.]+)/$')
 
-        self.assertEqual(self.a_router.parent_regex, u'a/(?P<a_pk>[^/]+)/')
+        self.assertEqual(self.a_router.parent_regex, u'a/(?P<a_pk>[^/.]+)/')
         urls = self.a_router.urls
         self.assertEquals(len(urls), 2)
-        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/]+)/b/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/]+)/b/(?P<pk>[^/]+)/$')
+        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<pk>[^/.]+)/$')
 
-        self.assertEqual(self.b_router.parent_regex, u'a/(?P<a_pk>[^/]+)/b/(?P<b_pk>[^/]+)/')
+        self.assertEqual(self.b_router.parent_regex, u'a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/')
         urls = self.b_router.urls
         self.assertEquals(len(urls), 2)
-        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/]+)/b/(?P<b_pk>[^/]+)/c/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/]+)/b/(?P<b_pk>[^/]+)/c/(?P<pk>[^/]+)/$')
+        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/c/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/c/(?P<pk>[^/.]+)/$')
+
+class TestNestedSimpleRouterWithRegex(TestCase):
+    def setUp(self):
+        self.router_regex = SimpleRouter()
+        self.router_regex.register(r'a', AViewSetWithRegex)
+        self.a_router_regex = NestedSimpleRouter(self.router_regex, r'a', lookup='a')
+        self.a_router_regex.register(r'b', BViewSetWithRegex)
+        self.b_router_regex = NestedSimpleRouter(self.a_router_regex, r'b', lookup='b')
+        self.b_router_regex.register(r'c', CViewSetWithRegex)
+
+    def test_recursive_nested_simple_routers_with_custom_lookup_regex(self):
+        self.assertFalse(hasattr(self.router_regex, 'parent_regex'))
+        urls = self.router_regex.urls
+        self.assertEquals(len(urls), 2)
+        self.assertEquals(urls[0].regex.pattern, u'^a/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<pk>[\d]{1,11})/$')
+
+        self.assertEqual(self.a_router_regex.parent_regex, u'a/(?P<a_pk>[\d]{{1,11}})/')
+        urls = self.a_router_regex.urls
+        self.assertEquals(len(urls), 2)
+        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[\d]{1,11})/b/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[\d]{1,11})/b/(?P<pk>[\d]{1,11})/$')
+
+        self.assertEqual(self.b_router_regex.parent_regex, u'a/(?P<a_pk>[\d]{{1,11}})/b/(?P<b_pk>[\d]{{1,11}})/')
+        urls = self.b_router_regex.urls
+        self.assertEquals(len(urls), 2)
+        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[\d]{1,11})/b/(?P<b_pk>[\d]{1,11})/c/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[\d]{1,11})/b/(?P<b_pk>[\d]{1,11})/c/(?P<pk>[\d]{1,11})/$')


### PR DESCRIPTION
No longer a need to subclass `rest_framework.routers.SimpleRouter`. It looks like DRF adopted your get_lookup_regex function and then expanded on it! :smiley:
Internally escapes { and } in `parent_regex` so that they will not cause problems when `.format()` is eventually called on URL templates.
Attempted to update the unit tests to reflect changes in DRF, but the test suite seems a little out of date to begin with.