### PR TITLE
Stop using LookupMixin

### DIFF
--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -27,34 +27,15 @@ Example:
 
 from __future__ import unicode_literals
 
-import rest_framework.routers
+from rest_framework.routers import SimpleRouter, DefaultRouter
 
 
 class LookupMixin(object):
-    def get_lookup_regex(self, viewset, lookup_prefix=''):
-        """
-        Given a viewset, return the portion of URL regex that is used
-        to match against a single instance.
-        """
-        base_regex = '(?P<{lookup_prefix}{lookup_field}>[^/]+)'
-        lookup_field = getattr(viewset, 'lookup_field', 'pk')
-        return base_regex.format(lookup_field=lookup_field, lookup_prefix=lookup_prefix)
-
-
-class SimpleRouter(LookupMixin, rest_framework.routers.SimpleRouter):
     """
-    Improvement of rest_framework.routers.SimpleRouter that allows the
-    lookup of urls of nested resources.
-    """
-    pass
+    Deprecated.
 
-
-class DefaultRouter(LookupMixin, rest_framework.routers.DefaultRouter):
+    No method override is needed since Django Rest Framework 2.4.
     """
-    Improvement of rest_framework.routers.DefaultRouter that allows the
-    lookup of urls of nested resources.
-    """
-    pass
 
 
 class NestedSimpleRouter(SimpleRouter):

--- a/rest_framework_nested/tests/test_routers.py
+++ b/rest_framework_nested/tests/test_routers.py
@@ -38,16 +38,16 @@ class TestNestedSimpleRouter(TestCase):
         urls = self.router.urls
         self.assertEquals(len(urls), 2)
         self.assertEquals(urls[0].regex.pattern, u'^a/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<pk>[^/]+)/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<pk>[^/.]+)/$')
 
-        self.assertEqual(self.a_router.parent_regex, u'a/(?P<a_pk>[^/]+)/')
+        self.assertEqual(self.a_router.parent_regex, u'a/(?P<a_pk>[^/.]+)/')
         urls = self.a_router.urls
         self.assertEquals(len(urls), 2)
-        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/]+)/b/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/]+)/b/(?P<pk>[^/]+)/$')
+        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<pk>[^/.]+)/$')
 
-        self.assertEqual(self.b_router.parent_regex, u'a/(?P<a_pk>[^/]+)/b/(?P<b_pk>[^/]+)/')
+        self.assertEqual(self.b_router.parent_regex, u'a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/')
         urls = self.b_router.urls
         self.assertEquals(len(urls), 2)
-        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/]+)/b/(?P<b_pk>[^/]+)/c/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/]+)/b/(?P<b_pk>[^/]+)/c/(?P<pk>[^/]+)/$')
+        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/c/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/c/(?P<pk>[^/.]+)/$')


### PR DESCRIPTION
I've left some things around just to keep backward compatibility:

* `LookupMixin` is retained, as an empty class, so that using it will not have any effect.
* `SimpleRouter` and `DefaultRouter` are now simply imported from `rest_framework` so that the names still exist in this module.

Here's a couple changes that aren't really breaking for this library, but may catch someone up if they're relying on an obscure undocumented part of this library:

* The lookup regex in Django Rest Framework uses `[^/.]` while we have used `[^/]`. This can be considered part of Django Rest Framework.
* `rest_framework.routers` no longer exists in this module. I've assumed that this isn't considered breaking because it's not part of the documented API.

It also has the side effect of fixing a bug where the `lookup_url_kwarg` on the viewset is not respected. Fixes #13.

The tests have been updated to reflect the lookup regex changes. I've not been able to run the tests to ensure they pass.

This is part of the work of #37. The rest of it may yet be interesting to investigate.