### PR TITLE
Correctly handle lookup_value_regex with {X} in it

### DIFF
--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -71,6 +71,7 @@ class NestedSimpleRouter(SimpleRouter):
 
         nested_routes = []
         parent_lookup_regex = parent_router.get_lookup_regex(parent_viewset, self.nest_prefix)
+
         self.parent_regex = '{parent_prefix}/{parent_lookup_regex}/'.format(
             parent_prefix=parent_prefix,
             parent_lookup_regex=parent_lookup_regex
@@ -81,7 +82,11 @@ class NestedSimpleRouter(SimpleRouter):
         for route in self.routes:
             route_contents = route._asdict()
 
-            route_contents['url'] = route.url.replace('^', '^'+self.parent_regex)
+            # This will get passed through .format in a little bit, so we need
+            # to escape it
+            escaped_parent_regex = self.parent_regex.replace('{', '{{').replace('}', '}}')
+
+            route_contents['url'] = route.url.replace('^', '^'+escaped_parent_regex)
             nested_routes.append(type(route)(**route_contents))
 
         self.routes = nested_routes

--- a/rest_framework_nested/tests/test_routers.py
+++ b/rest_framework_nested/tests/test_routers.py
@@ -16,6 +16,7 @@ class C(models.Model):
     parent=models.ForeignKey(B)
 
 class AViewSet(ModelViewSet):
+    lookup_value_regex = '[0-9a-f]{32}'
     model = A
 
 class BViewSet(ModelViewSet):
@@ -38,16 +39,16 @@ class TestNestedSimpleRouter(TestCase):
         urls = self.router.urls
         self.assertEquals(len(urls), 2)
         self.assertEquals(urls[0].regex.pattern, u'^a/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<pk>[^/.]+)/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<pk>[0-9a-f]{32})/$')
 
-        self.assertEqual(self.a_router.parent_regex, u'a/(?P<a_pk>[^/.]+)/')
+        self.assertEqual(self.a_router.parent_regex, u'a/(?P<a_pk>[0-9a-f]{32})/')
         urls = self.a_router.urls
         self.assertEquals(len(urls), 2)
-        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<pk>[^/.]+)/$')
+        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[0-9a-f]{32})/b/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[0-9a-f]{32})/b/(?P<pk>[^/.]+)/$')
 
-        self.assertEqual(self.b_router.parent_regex, u'a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/')
+        self.assertEqual(self.b_router.parent_regex, u'a/(?P<a_pk>[0-9a-f]{32})/b/(?P<b_pk>[^/.]+)/')
         urls = self.b_router.urls
         self.assertEquals(len(urls), 2)
-        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/c/$')
-        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[^/.]+)/b/(?P<b_pk>[^/.]+)/c/(?P<pk>[^/.]+)/$')
+        self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[0-9a-f]{32})/b/(?P<b_pk>[^/.]+)/c/$')
+        self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[0-9a-f]{32})/b/(?P<b_pk>[^/.]+)/c/(?P<pk>[^/.]+)/$')


### PR DESCRIPTION
Without this, if your lookup_value_regex has a '{X}' pattern in it,
your url patterns will fail to compile because it gets passed through
.format.

If you escape it yourself (turning '{' into '{{' and '}' into '}}'),
it only works on the leaf level. Top level resources use the '{{'
literally, and then your regexes of course don't match anymore.