### PR TITLE
Cover various Python, Django and DRF versions for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 language: python
 python: # test various python versions, Django supports all of them
-  - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-language: python
-python: # test various python versions, Django supports all of them
-  - "3.5"
 
 cache: pip
 
@@ -49,12 +46,6 @@ env:
     - TOX_ENV=py34-django1.9-drf3.5
     - TOX_ENV=py34-django1.10-drf3.3
     - TOX_ENV=py34-django1.10-drf3.5
-    - TOX_ENV=py35-django1.8-drf3.3
-    - TOX_ENV=py35-django1.8-drf3.5
-    - TOX_ENV=py35-django1.9-drf3.3
-    - TOX_ENV=py35-django1.9-drf3.5
-    - TOX_ENV=py35-django1.10-drf3.3
-    - TOX_ENV=py35-django1.10-drf3.5
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: python
+language: python
+python: # test various python versions, Django supports all of them
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ env:
     - TOX_ENV=py27-django1.8-drf2.4
     - TOX_ENV=py27-django1.8-drf3.0
     - TOX_ENV=py27-django1.8-drf3.1
+    - TOX_ENV=py27-django1.8-drf3.3
+    - TOX_ENV=py27-django1.8-drf3.5
+    - TOX_ENV=py27-django1.9-drf3.3
+    - TOX_ENV=py27-django1.9-drf3.5
+    - TOX_ENV=py27-django1.10-drf3.3
+    - TOX_ENV=py27-django1.10-drf3.5
     - TOX_ENV=py33-django1.6-drf2.4
     - TOX_ENV=py33-django1.6-drf3.0
     - TOX_ENV=py33-django1.6-drf3.1
@@ -34,6 +40,18 @@ env:
     - TOX_ENV=py34-django1.8-drf2.4
     - TOX_ENV=py34-django1.8-drf3.0
     - TOX_ENV=py34-django1.8-drf3.1
+    - TOX_ENV=py34-django1.8-drf3.3
+    - TOX_ENV=py34-django1.8-drf3.5
+    - TOX_ENV=py34-django1.9-drf3.3
+    - TOX_ENV=py34-django1.9-drf3.5
+    - TOX_ENV=py34-django1.10-drf3.3
+    - TOX_ENV=py34-django1.10-drf3.5
+    - TOX_ENV=py35-django1.8-drf3.3
+    - TOX_ENV=py35-django1.8-drf3.5
+    - TOX_ENV=py35-django1.9-drf3.3
+    - TOX_ENV=py35-django1.9-drf3.5
+    - TOX_ENV=py35-django1.10-drf3.3
+    - TOX_ENV=py35-django1.10-drf3.5
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ drf-nested-routers
 =====================
 
 [![Join the chat at https://gitter.im/alanjds/drf-nested-routers](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/alanjds/drf-nested-routers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/alanjds/drf-nested-routers.svg?branch=master)](https://travis-ci.org/alanjds/drf-nested-routers)
+[![Build Status](https://travis-ci.org/christiankreuzberger/drf-nested-routers.svg?branch=master)](https://travis-ci.org/christiankreuzberger/drf-nested-routers)
 
 This package provides routers and fields to create nested resources in the [Django Rest Framework](http://django-rest-framework.org/)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ drf-nested-routers
 =====================
 
 [![Join the chat at https://gitter.im/alanjds/drf-nested-routers](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/alanjds/drf-nested-routers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/christiankreuzberger/drf-nested-routers.svg?branch=master)](https://travis-ci.org/christiankreuzberger/drf-nested-routers)
+[![Build Status](https://travis-ci.org/alanjds/drf-nested-routers.svg?branch=master)](https://travis-ci.org/alanjds/drf-nested-routers)
 
 This package provides routers and fields to create nested resources in the [Django Rest Framework](http://django-rest-framework.org/)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django{1.6,1.7,1.8}-drf{2.4,3.0,3.1}
+       {py27,py33,py34,py35}-django{1.6,1.7,1.8,1.9,1.10}-drf{2.4,3.0,3.1,3.3,3.5}
 
 [testenv]
 commands = ./runtests.py --nolint
@@ -11,9 +11,13 @@ deps =
        django1.6: Django==1.6.11
        django1.7: Django==1.7.8
        django1.8: Django==1.8
+       django1.9: Django==1.9
+       django1.10: Django==1.10.3
        drf2.4: djangorestframework==2.4.4
        drf3.0: djangorestframework==3.0.5
        drf3.1: djangorestframework==3.1.3
+       drf3.3: djangorestframework==3.3.3
+       drf3.5: djangorestframework==3.5.3
        pytest-django==2.8.0
        -rrequirements-tox.txt
 


### PR DESCRIPTION
Hi!

Is there a reason why the tox tests do not cover various newer versions of Python as well as Django and DRF? [Travis](https://travis-ci.org/ChristianKreuzberger/drf-nested-routers) seems to be fine with it.

