### PR TITLE
Nested hyperlinked urls v2

### DIFF
--- a/rest_framework_nested/relations.py
+++ b/rest_framework_nested/relations.py
@@ -5,8 +5,18 @@ These fields allow you to specify the style that should be used to represent
 model relationships with hyperlinks.
 """
 from __future__ import unicode_literals
+from collections import Iterable
+from functools import reduce  # import reduce from functools for compatibility with python 3
+from django.core.exceptions import ImproperlyConfigured
 
 import rest_framework.relations
+
+
+# fix for basestring
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedField):
@@ -28,21 +38,53 @@ class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedF
         attributes are not configured to correctly match the URL conf.
         """
         # Unsaved objects will not yet have a valid URL.
-        if hasattr(obj, 'pk') and obj.pk is None:
+        if hasattr(obj, 'pk') and obj.pk in (None, ''):
             return None
-        pk_url_kwarg = 'pk'
 
+        # check if lookup field exists
+        if not hasattr(obj, self.lookup_field):
+            raise ImproperlyConfigured(
+                "Object %(obj)s does not have a field %(lookup_field)s" %
+                {'obj': str(obj), 'lookup_field': self.lookup_field}
+            )
+
+        # get value of the primary lookup field
         lookup_value = getattr(obj, self.lookup_field)
-        parent_lookup_object = getattr(obj, self.parent_lookup_field)
-        parent_lookup_value = getattr(
-            parent_lookup_object,
-            self.parent_lookup_related_field
-        ) if parent_lookup_object else None
 
+        # set up kwargs with the initial lookup kwarg
         kwargs = {
             self.lookup_url_kwarg: lookup_value,
-            self.parent_lookup_url_kwarg: parent_lookup_value,
         }
+
+        if isinstance(self.parent_lookup_url_kwarg, basestring):
+            parent_lookup_object = getattr(obj, self.parent_lookup_field)
+            parent_lookup_value = getattr(
+                parent_lookup_object,
+                self.parent_lookup_related_field
+            ) if parent_lookup_object else None
+
+            kwargs.update({self.parent_lookup_url_kwarg: parent_lookup_value})
+        elif isinstance(self.parent_lookup_url_kwarg, Iterable):
+            # iterate over all lookup fields, e.g. ("parent__pk", "pk")
+            for underscored_lookup in self.parent_lookup_url_kwarg:
+                # FIXME: handle errors
+
+                # split each lookup by their __, e.g. "parent__pk" will be split into "parent" and "pk", or
+                # "parent__super__pk" would be split itno "parent", "super" and "pk"
+                lookups = underscored_lookup.split('__')
+
+                # use the Django ORM to lookup this value, e.g., obj.parent.pk
+                value = reduce(getattr, [obj] + lookups)
+
+                # the lookup name needs to be created with single "_", and must only contain the last two entries of the
+                # lookup field; "parent__super__pk" would be converted into "super_pk" and "parent__pk" into "parent_pk"
+                lookup_name = "_".join(lookups[-2:])
+
+                # store the lookup_name and value in kwargs, which is later passed to the reverse method
+                kwargs.update({lookup_name: value})
+            # end for
+        # end if
+
         return self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
     def get_object(self, view_name, view_args, view_kwargs):

--- a/rest_framework_nested/serializers.py
+++ b/rest_framework_nested/serializers.py
@@ -1,10 +1,11 @@
+from django.core.exceptions import ImproperlyConfigured
 import rest_framework.serializers
 from rest_framework_nested.relations import NestedHyperlinkedIdentityField
 try:
     from rest_framework.utils.field_mapping import get_nested_relation_kwargs
 except ImportError:
-    pass # passing because NestedHyperlinkedModelSerializer can't be used anyway
-         #    if version too old.
+    pass  # passing because NestedHyperlinkedModelSerializer can't be used anyway
+    #    if version too old.
 
 
 class NestedHyperlinkedModelSerializer(rest_framework.serializers.HyperlinkedModelSerializer):
@@ -20,13 +21,28 @@ class NestedHyperlinkedModelSerializer(rest_framework.serializers.HyperlinkedMod
     parent_lookup_field = 'parent'
     parent_lookup_related_field = 'pk'
     parent_lookup_url_kwarg = 'parent_pk'
+    parent_lookup_kwargs = {}
 
     serializer_url_field = NestedHyperlinkedIdentityField
 
     def __init__(self, *args, **kwargs):
-        self.parent_lookup_field = kwargs.pop('parent_lookup_field', self.parent_lookup_field)
-        self.parent_lookup_related_field = kwargs.pop('parent_lookup_related_field', self.parent_lookup_related_field)
-        self.parent_lookup_url_kwarg = kwargs.pop('parent_lookup_url_kwarg', self.parent_lookup_url_kwarg)
+        # check that config parameters are not mixed
+        if 'parent_lookup_kwargs' in kwargs and \
+                ('parent_lookup_field' in kwargs or 'parent_lookup_related_field' in kwargs
+                 or 'parent_lookup_url_kwarg' in kwargs):
+            raise ImproperlyConfigured("Do not mix parent_lookup_kwargs with any of the following: "
+                                       "parent_lookup_field, parent_lookup_related_field, parent_lookup_url_kwarg")
+
+        if 'parent_lookup_kwargs' in kwargs:
+            self.parent_lookup_kwargs = kwargs.pop('parent_lookup_kwargs', self.parent_lookup_kwargs)
+            self.parent_lookup_field = None
+            self.parent_lookup_related_field = None
+            self.parent_lookup_url_kwarg = None
+        else:
+            self.parent_lookup_kwargs = None
+            self.parent_lookup_field = kwargs.pop('parent_lookup_field', self.parent_lookup_field)
+            self.parent_lookup_related_field = kwargs.pop('parent_lookup_related_field', self.parent_lookup_related_field)
+            self.parent_lookup_url_kwarg = kwargs.pop('parent_lookup_url_kwarg', self.parent_lookup_url_kwarg)
 
         return super(NestedHyperlinkedModelSerializer, self).__init__(*args, **kwargs)
 
@@ -35,6 +51,7 @@ class NestedHyperlinkedModelSerializer(rest_framework.serializers.HyperlinkedMod
         field_kwargs['parent_lookup_field'] = self.parent_lookup_field
         field_kwargs['parent_lookup_related_field'] = self.parent_lookup_related_field
         field_kwargs['parent_lookup_url_kwarg'] = self.parent_lookup_url_kwarg
+        field_kwargs['parent_lookup_kwargs'] = self.parent_lookup_kwargs
 
         return field_class, field_kwargs
 

--- a/tests/serializers/models.py
+++ b/tests/serializers/models.py
@@ -41,8 +41,11 @@ class ParentChild1Serializer(nested_serializers.NestedHyperlinkedModelSerializer
 
 
 class ParentChild2GrandChild1Serializer(nested_serializers.NestedHyperlinkedModelSerializer):
-    parent_lookup_url_kwarg = ('parent__pk', 'parent__root__pk')
-    parent_lookup_field = 'parent'
+    parent_lookup_kwargs = {
+        'pk': 'pk',
+        'parent_pk': 'parent__pk',
+        'root_pk': 'parent__root__pk'
+    }
 
     class Meta:
         model = GrandChild1
@@ -57,7 +60,14 @@ class ParentChild2Serializer(nested_serializers.NestedHyperlinkedModelSerializer
         model = Child2
         fields = ('url', 'name', 'grand')
 
-    grand = ParentChild2GrandChild1Serializer(many=True, read_only=True)
+    grand = ParentChild2GrandChild1Serializer(
+        many=True, read_only=True,
+        parent_lookup_kwargs={
+            'pk': 'pk',
+            'parent_pk': 'parent__pk',
+            'root_pk': 'parent__root__pk'
+        }
+    )
 
 
 class Parent1Serializer(serializers.ModelSerializer):

--- a/tests/serializers/models.py
+++ b/tests/serializers/models.py
@@ -17,6 +17,11 @@ class Child2(models.Model):
     root = models.ForeignKey(Parent, related_name='second')
 
 
+class GrandChild1(models.Model):
+    name = models.CharField(max_length=10)
+    parent = models.ForeignKey(Child2, related_name='grand')
+
+
 class Child1Serializer(serializers.ModelSerializer):
     class Meta:
         model = Child1
@@ -35,13 +40,24 @@ class ParentChild1Serializer(nested_serializers.NestedHyperlinkedModelSerializer
         fields = ('url', 'name')
 
 
+class ParentChild2GrandChild1Serializer(nested_serializers.NestedHyperlinkedModelSerializer):
+    parent_lookup_url_kwarg = ('parent__pk', 'parent__root__pk')
+    parent_lookup_field = 'parent'
+
+    class Meta:
+        model = GrandChild1
+        fields = ('url', 'name')
+
+
 class ParentChild2Serializer(nested_serializers.NestedHyperlinkedModelSerializer):
     parent_lookup_url_kwarg = 'root_pk'
     parent_lookup_field = 'root'
 
     class Meta:
         model = Child2
-        fields = ('url', 'name')
+        fields = ('url', 'name', 'grand')
+
+    grand = ParentChild2GrandChild1Serializer(many=True, read_only=True)
 
 
 class Parent1Serializer(serializers.ModelSerializer):
@@ -78,3 +94,8 @@ class Child1Viewset(viewsets.ModelViewSet):
 class Child2Viewset(viewsets.ModelViewSet):
     serializer_class = Child2Serializer
     queryset = Child2.objects.all()
+
+
+class ParentChild2GrandChild1Viewset(viewsets.ModelViewSet):
+    serializer_class = ParentChild2GrandChild1Serializer
+    queryset = GrandChild1.objects.all()

--- a/tests/serializers/test_serializers.py
+++ b/tests/serializers/test_serializers.py
@@ -3,7 +3,7 @@ import pytest
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-from tests.serializers.models import Parent, Child1, Child2
+from tests.serializers.models import Parent, Child1, Child2, GrandChild1
 
 
 class TestSerializers(TestCase):
@@ -22,9 +22,14 @@ class TestSerializers(TestCase):
         Child1.objects.create(parent=parent, name='Child1-B')
         Child1.objects.create(parent=parent, name='Child1-C')
 
-        Child2.objects.create(root=parent, name='Child2-A')
+        child2 = Child2.objects.create(root=parent, name='Child2-A')
         Child2.objects.create(root=parent, name='Child2-B')
         Child2.objects.create(root=parent, name='Child2-C')
+
+        GrandChild1.objects.create(parent=child2, name='Child2-GrandChild1-A')
+        GrandChild1.objects.create(parent=child2, name='Child2-GrandChild1-B')
+        GrandChild1.objects.create(parent=child2, name='Child2-GrandChild1-C')
+
 
         Parent.objects.create(name='Parent2')
         return super(TestSerializers, cls).setUpClass()
@@ -40,7 +45,6 @@ class TestSerializers(TestCase):
         self.assertIn('/parent1/1/child1/3/', data['first'][2]['url'])
 
     def test_custom(self):
-        return
         url = reverse('parent2-detail', kwargs={'pk': 1})
         data = self.get_json_response(url)
 

--- a/tests/serializers/urls.py
+++ b/tests/serializers/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url, include
 from rest_framework_nested import routers
 
-from tests.serializers.models import Parent1Viewset, Child1Viewset, Parent2Viewset, Child2Viewset
+from tests.serializers.models import Parent1Viewset, Child1Viewset, Parent2Viewset, Child2Viewset, ParentChild2GrandChild1Viewset
 
 
 router_1 = routers.SimpleRouter()
@@ -14,9 +14,13 @@ router_2.register('parent2', Parent2Viewset, base_name='parent2')
 parent_2_router = routers.NestedSimpleRouter(router_2, r'parent2', lookup='root')
 parent_2_router.register(r'child2', Child2Viewset, base_name='child2')
 
+parent_2_grandchild_router = routers.NestedSimpleRouter(parent_2_router, r'child2', lookup='parent')
+parent_2_grandchild_router.register(r'grandchild1', ParentChild2GrandChild1Viewset, base_name='grandchild1')
+
 urlpatterns = [
     url(r'^', include(router_1.urls)),
     url(r'^', include(parent_1_router.urls)),
     url(r'^', include(router_2.urls)),
     url(r'^', include(parent_2_router.urls)),
+    url(r'^', include(parent_2_grandchild_router.urls)),
 ]


### PR DESCRIPTION
In my last PR #87 I was completely unaware that the current master already had some functionality for nested views ( @lwm sorry for the extra work, but this PR should be much better than the last one).

This PR allows for a url configuration like this:

```
/parent2/
/parent2/{pk}/
/parent2/{pk}/child2/
/parent2/{pk}/child2/{pk}/
/parent2/{pk}/child2/{pk}/grandchild1/
/parent2/{pk}/child2/{pk}/grandchild1/{pk}/
```

At each level the URLs are properly resolved, which is also due to the fact that ``ParentChild2GrandChild1Serializer`` has a different way of configuring it:
```python
parent_lookup_url_kwarg = ('parent__pk', 'parent__root__pk')
```
The PR updates the ``NestedHyperlinkedRelatedField`` as follows:

 * Keep compatibility with the string version of the lookup
 * Allow lookups of multiple nested levels by using Django ORMs '__' syntax.


The main logic works as follows:
```python
            for underscored_lookup in self.parent_lookup_url_kwarg:
                # FIXME: handle errors

                # split each lookup by their __, e.g. "parent__pk" will be split into "parent" and "pk", or
                # "parent__super__pk" would be split itno "parent", "super" and "pk"
                lookups = underscored_lookup.split('__')

                # use the Django ORM to lookup this value, e.g., obj.parent.pk
                value = reduce(getattr, [obj] + lookups)

                # the lookup name needs to be created with single "_", and must only contain the last two entries of the
                # lookup field; "parent__super__pk" would be converted into "super_pk" and "parent__pk" into "parent_pk"
                lookup_name = "_".join(lookups[-2:])

                # store the lookup_name and value in kwargs, which is later passed to the reverse method
                kwargs.update({lookup_name: value})
```

I still have one *FIXME* left to do, though I'm not sure which errors we should except here. The code could most likely fail at ``value = reduce(getattr, [obj] + lookups)`` (e.g. when the lookup does not exist), and maybe at `` lookup_name = "_".join(lookups[-2:])`` if lookups is empty (though that would be a check we can do right after splitting the lookup fields...).
Maybe someone has a good idea on what exceptions to except here?


Please see [tests/serializers/models.py]() for details on configuring the serializers and URLs.
