### PR TITLE
Add test support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,18 @@ env:
     - TOX_ENV=py34-django1.9-drf3.5
     - TOX_ENV=py34-django1.10-drf3.3
     - TOX_ENV=py34-django1.10-drf3.5
+    - TOX_ENV=py35-django1.8-drf3.3
+    - TOX_ENV=py35-django1.8-drf3.5
+    - TOX_ENV=py35-django1.9-drf3.3
+    - TOX_ENV=py35-django1.9-drf3.5
+    - TOX_ENV=py35-django1.10-drf3.3
+    - TOX_ENV=py35-django1.10-drf3.5
+    - TOX_ENV=py36-django1.8-drf3.3
+    - TOX_ENV=py36-django1.8-drf3.5
+    - TOX_ENV=py36-django1.9-drf3.3
+    - TOX_ENV=py36-django1.9-drf3.5
+    - TOX_ENV=py36-django1.10-drf3.3
+    - TOX_ENV=py36-django1.10-drf3.5
 
 matrix:
   fast_finish: true

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Nested resources for the Django Rest Framework
 Requirements
 ------------
 
--  Python (2.7, 3.3, 3.4)
+-  Python (2.7, 3.3, 3.4, 3.5, 3.6)
 -  Django (1.6, 1.7, 1.8)
 -  Django REST Framework (2.4, 3.0, 3.1)
 

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Requirements
 ------------
 
 -  Python (2.7, 3.3, 3.4, 3.5, 3.6)
--  Django (1.6, 1.7, 1.8)
--  Django REST Framework (2.4, 3.0, 3.1)
+-  Django (1.6, 1.7, 1.8, 1.9, 1.10)
+-  Django REST Framework (2.4, 3.0, 3.1, 3.3, 3.5)
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34,py35}-django{1.6,1.7,1.8,1.9,1.10}-drf{2.4,3.0,3.1,3.3,3.5}
+       {py27,py33,py34,py35,py36}-django{1.6,1.7,1.8,1.9,1.10}-drf{2.4,3.0,3.1,3.3,3.5}
 
 [testenv]
 commands = ./runtests.py --nolint


### PR DESCRIPTION
Add support for Python 3.6 to the test environment and update documentation accordingly.

drf-nested-routers appears to 'just work' for me under Python 3.6.0, DRF 3.5.3, and Django 1.10.4, so why not make that official?