### PR TITLE
New release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,20 @@
+sudo: false
+
 language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+install: pip install tox-travis
+script: tox
 
 cache: pip
 
-sudo: false
-
-env:
-    #- TOX_ENV=py27-flake8
-    - TOX_ENV=py27-docs
-    - TOX_ENV=py27-django1.6-drf2.4
-    - TOX_ENV=py27-django1.6-drf3.0
-    - TOX_ENV=py27-django1.6-drf3.1
-    - TOX_ENV=py27-django1.7-drf2.4
-    - TOX_ENV=py27-django1.7-drf3.0
-    - TOX_ENV=py27-django1.7-drf3.1
-    - TOX_ENV=py27-django1.8-drf2.4
-    - TOX_ENV=py27-django1.8-drf3.0
-    - TOX_ENV=py27-django1.8-drf3.1
-    - TOX_ENV=py27-django1.8-drf3.3
-    - TOX_ENV=py27-django1.8-drf3.5
-    - TOX_ENV=py27-django1.9-drf3.3
-    - TOX_ENV=py27-django1.9-drf3.5
-    - TOX_ENV=py27-django1.10-drf3.3
-    - TOX_ENV=py27-django1.10-drf3.5
-    - TOX_ENV=py33-django1.6-drf2.4
-    - TOX_ENV=py33-django1.6-drf3.0
-    - TOX_ENV=py33-django1.6-drf3.1
-    - TOX_ENV=py33-django1.7-drf2.4
-    - TOX_ENV=py33-django1.7-drf3.0
-    - TOX_ENV=py33-django1.7-drf3.1
-    - TOX_ENV=py33-django1.8-drf2.4
-    - TOX_ENV=py33-django1.8-drf3.0
-    - TOX_ENV=py33-django1.8-drf3.1
-    - TOX_ENV=py34-django1.6-drf2.4
-    - TOX_ENV=py34-django1.6-drf3.0
-    - TOX_ENV=py34-django1.6-drf3.1
-    - TOX_ENV=py34-django1.7-drf2.4
-    - TOX_ENV=py34-django1.7-drf3.0
-    - TOX_ENV=py34-django1.7-drf3.1
-    - TOX_ENV=py34-django1.8-drf2.4
-    - TOX_ENV=py34-django1.8-drf3.0
-    - TOX_ENV=py34-django1.8-drf3.1
-    - TOX_ENV=py34-django1.8-drf3.3
-    - TOX_ENV=py34-django1.8-drf3.5
-    - TOX_ENV=py34-django1.9-drf3.3
-    - TOX_ENV=py34-django1.9-drf3.5
-    - TOX_ENV=py34-django1.10-drf3.3
-    - TOX_ENV=py34-django1.10-drf3.5
-
 matrix:
   fast_finish: true
-
-install:
-  - pip install tox
-
-script:
-    - tox -e $TOX_ENV
 
 notifications:
     webhooks:

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ In order to get started with testing, you will need to install [tox](https://tox
 Once installed, you can then run one environment locally, to speed up your development cycle:
 
 ```
-$ tox -e py27-django1.6-drf3.0
+$ tox -e py27-django1.8-drf3.0
 ```
 
 Once you submit a pull request, your changes will be run against many environments with Travis.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ class DomainSerializer(HyperlinkedModelSerializer):
         many=True,
         read_only=True,   # Or add a queryset
         view_name='domain-nameservers-detail'
-        parent_lookup_url_kwarg='domain_pk'
+        parent_lookup_url_kwargs={'domain_pk': 'domain__pk'}
     )
 ```
 
@@ -104,7 +104,9 @@ class NameserverSerializers(HyperlinkedModelSerializer):
 
 
 class DomainNameserverSerializers(NestedHyperlinkedModelSerializer):
-	parent_lookup_url_kwarg='domain_pk'
+	parent_lookup_kwargs = {
+		'domain_pk': 'domain__pk',
+	}
 	class Meta:
 		model = Nameserver
 		fields = ('url', ...)

--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,9 @@ Nested resources for the Django Rest Framework
 Requirements
 ------------
 
--  Python (2.7, 3.3, 3.4)
--  Django (1.6, 1.7, 1.8)
--  Django REST Framework (2.4, 3.0, 3.1)
+-  Python (2.7, 3.3, 3.4, 3.5, 3.6)
+-  Django (1.8, 1.9, 1.10)
+-  Django REST Framework (2.4.3, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5)
 
 Installation
 ------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ Nested resources for the Django Rest Framework
 
 ## Requirements
 
-* Python (2.7, 3.3, 3.4)
-* Django (1.6, 1.7)
+* Python (2.7, 3.3, 3.4, 3.5, 3.6)
+* Django (1.8, 1.9, 1.10)
 
 ## Installation
 

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -1,6 +1,7 @@
 # Test requirements
 pytest-cov==1.6
 flake8==2.4.0
+ipdb
 
 # wheel for PyPI installs
 wheel==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -r requirements-tox.txt
 
 # Minimum Django and REST framework version
-Django>=1.6
+Django>=1.8
 djangorestframework>=2.4.3
 
 # Test requirements

--- a/rest_framework_nested/relations.py
+++ b/rest_framework_nested/relations.py
@@ -5,19 +5,30 @@ These fields allow you to specify the style that should be used to represent
 model relationships with hyperlinks.
 """
 from __future__ import unicode_literals
+from functools import reduce  # import reduce from functools for compatibility with python 3
+from django.core.exceptions import ImproperlyConfigured
 
 import rest_framework.relations
+
+
+# fix for basestring
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedField):
     lookup_field = 'pk'
     parent_lookup_field = 'parent'
     parent_lookup_related_field = 'pk'
+    parent_lookup_kwargs = None
 
     def __init__(self, *args, **kwargs):
         self.parent_lookup_field = kwargs.pop('parent_lookup_field', self.parent_lookup_field)
         self.parent_lookup_url_kwarg = kwargs.pop('parent_lookup_url_kwarg', self.parent_lookup_field)
         self.parent_lookup_related_field = kwargs.pop('parent_lookup_related_field', self.parent_lookup_related_field)
+        self.parent_lookup_kwargs = kwargs.pop('parent_lookup_kwargs', self.parent_lookup_kwargs)
         super(NestedHyperlinkedRelatedField, self).__init__(*args, **kwargs)
 
     def get_url(self, obj, view_name, request, format):
@@ -28,20 +39,49 @@ class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedF
         attributes are not configured to correctly match the URL conf.
         """
         # Unsaved objects will not yet have a valid URL.
-        if hasattr(obj, 'pk') and obj.pk is None:
+        if hasattr(obj, 'pk') and obj.pk in (None, ''):
             return None
 
-        lookup_value = getattr(obj, self.lookup_field)
-        parent_lookup_object = getattr(obj, self.parent_lookup_field)
-        parent_lookup_value = getattr(
-            parent_lookup_object,
-            self.parent_lookup_related_field
-        ) if parent_lookup_object else None
+        kwargs = {}
 
-        kwargs = {
-            self.lookup_url_kwarg: lookup_value,
-            self.parent_lookup_url_kwarg: parent_lookup_value,
-        }
+        if self.parent_lookup_kwargs:
+            # iterate over all lookup fields, e.g. ("parent__pk", "pk")
+            for lookup_url_kwarg in self.parent_lookup_kwargs.keys():
+                # FIXME: handle errors
+                underscored_lookup = self.parent_lookup_kwargs[lookup_url_kwarg]
+
+                # split each lookup by their __, e.g. "parent__pk" will be split into "parent" and "pk", or
+                # "parent__super__pk" would be split into "parent", "super" and "pk"
+                lookups = underscored_lookup.split('__')
+
+                # use the Django ORM to lookup this value, e.g., obj.parent.pk
+                lookup_value = reduce(getattr, [obj] + lookups)
+
+                # store the lookup_name and value in kwargs, which is later passed to the reverse method
+                kwargs.update({lookup_url_kwarg: lookup_value})
+            # end for
+        else:
+            # check if lookup field exists
+            if not hasattr(obj, self.lookup_field):
+                raise ImproperlyConfigured(
+                    "Object %(obj)s does not have a field %(lookup_field)s" %
+                    {'obj': str(obj), 'lookup_field': self.lookup_field}
+                )
+
+            # get value of the primary lookup field
+            lookup_value = getattr(obj, self.lookup_field)
+
+            # set up kwargs with the initial lookup kwarg
+            kwargs.update({self.lookup_url_kwarg: lookup_value})
+
+            parent_lookup_object = getattr(obj, self.parent_lookup_field)
+            parent_lookup_value = getattr(
+                parent_lookup_object,
+                self.parent_lookup_related_field
+            ) if parent_lookup_object else None
+
+            kwargs.update({self.parent_lookup_url_kwarg: parent_lookup_value})
+
         return self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
     def get_object(self, view_name, view_args, view_kwargs):

--- a/rest_framework_nested/relations.py
+++ b/rest_framework_nested/relations.py
@@ -6,7 +6,6 @@ model relationships with hyperlinks.
 """
 from __future__ import unicode_literals
 from functools import reduce  # import reduce from functools for compatibility with python 3
-from django.core.exceptions import ImproperlyConfigured
 
 import rest_framework.relations
 
@@ -20,14 +19,11 @@ except NameError:
 
 class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedField):
     lookup_field = 'pk'
-    parent_lookup_field = 'parent'
-    parent_lookup_related_field = 'pk'
-    parent_lookup_kwargs = None
+    parent_lookup_kwargs = {
+        'parent_pk': 'parent__pk'
+    }
 
     def __init__(self, *args, **kwargs):
-        self.parent_lookup_field = kwargs.pop('parent_lookup_field', self.parent_lookup_field)
-        self.parent_lookup_url_kwarg = kwargs.pop('parent_lookup_url_kwarg', self.parent_lookup_field)
-        self.parent_lookup_related_field = kwargs.pop('parent_lookup_related_field', self.parent_lookup_related_field)
         self.parent_lookup_kwargs = kwargs.pop('parent_lookup_kwargs', self.parent_lookup_kwargs)
         super(NestedHyperlinkedRelatedField, self).__init__(*args, **kwargs)
 
@@ -42,45 +38,23 @@ class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedF
         if hasattr(obj, 'pk') and obj.pk in (None, ''):
             return None
 
-        kwargs = {}
+        # default lookup from rest_framework.relations.HyperlinkedRelatedField
+        lookup_value = getattr(obj, self.lookup_field)
+        kwargs = {self.lookup_url_kwarg: lookup_value}
 
-        if self.parent_lookup_kwargs:
-            # iterate over all lookup fields, e.g. ("parent__pk", "pk")
-            for lookup_url_kwarg in self.parent_lookup_kwargs.keys():
-                # FIXME: handle errors
-                underscored_lookup = self.parent_lookup_kwargs[lookup_url_kwarg]
+        # multi-level lookup
+        for parent_lookup_kwarg in list(self.parent_lookup_kwargs.keys()):
+            underscored_lookup = self.parent_lookup_kwargs[parent_lookup_kwarg]
 
-                # split each lookup by their __, e.g. "parent__pk" will be split into "parent" and "pk", or
-                # "parent__super__pk" would be split into "parent", "super" and "pk"
-                lookups = underscored_lookup.split('__')
+            # split each lookup by their __, e.g. "parent__pk" will be split into "parent" and "pk", or
+            # "parent__super__pk" would be split into "parent", "super" and "pk"
+            lookups = underscored_lookup.split('__')
 
-                # use the Django ORM to lookup this value, e.g., obj.parent.pk
-                lookup_value = reduce(getattr, [obj] + lookups)
+            # use the Django ORM to lookup this value, e.g., obj.parent.pk
+            lookup_value = reduce(getattr, [obj] + lookups)
 
-                # store the lookup_name and value in kwargs, which is later passed to the reverse method
-                kwargs.update({lookup_url_kwarg: lookup_value})
-            # end for
-        else:
-            # check if lookup field exists
-            if not hasattr(obj, self.lookup_field):
-                raise ImproperlyConfigured(
-                    "Object %(obj)s does not have a field %(lookup_field)s" %
-                    {'obj': str(obj), 'lookup_field': self.lookup_field}
-                )
-
-            # get value of the primary lookup field
-            lookup_value = getattr(obj, self.lookup_field)
-
-            # set up kwargs with the initial lookup kwarg
-            kwargs.update({self.lookup_url_kwarg: lookup_value})
-
-            parent_lookup_object = getattr(obj, self.parent_lookup_field)
-            parent_lookup_value = getattr(
-                parent_lookup_object,
-                self.parent_lookup_related_field
-            ) if parent_lookup_object else None
-
-            kwargs.update({self.parent_lookup_url_kwarg: parent_lookup_value})
+            # store the lookup_name and value in kwargs, which is later passed to the reverse method
+            kwargs.update({parent_lookup_kwarg: lookup_value})
 
         return self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
@@ -91,13 +65,17 @@ class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedF
         Takes the matched URL conf arguments, and should return an
         object instance, or raise an `ObjectDoesNotExist` exception.
         """
+
+        # default lookup from rest_framework.relations.HyperlinkedRelatedField
         lookup_value = view_kwargs[self.lookup_url_kwarg]
-        parent_lookup_value = view_kwargs[self.parent_lookup_url_kwarg]
-        lookup_kwargs = {
-            self.lookup_field: lookup_value,
-            self.parent_lookup_field: parent_lookup_value,
-        }
-        return self.get_queryset().get(**lookup_kwargs)
+        kwargs = {self.lookup_url_kwarg: lookup_value}
+
+        # multi-level lookup
+        for parent_lookup_kwarg in list(self.parent_lookup_kwargs.keys()):
+            lookup_value = view_kwargs[parent_lookup_kwarg]
+            kwargs.update({parent_lookup_kwarg: lookup_value})
+
+            return self.get_queryset().get(**kwargs)
 
 
 class NestedHyperlinkedIdentityField(NestedHyperlinkedRelatedField):

--- a/rest_framework_nested/relations.py
+++ b/rest_framework_nested/relations.py
@@ -30,7 +30,6 @@ class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedF
         # Unsaved objects will not yet have a valid URL.
         if hasattr(obj, 'pk') and obj.pk is None:
             return None
-        pk_url_kwarg = 'pk'
 
         lookup_value = getattr(obj, self.lookup_field)
         parent_lookup_object = getattr(obj, self.parent_lookup_field)

--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -27,7 +27,7 @@ Example:
 
 from __future__ import unicode_literals
 
-from rest_framework.routers import SimpleRouter, DefaultRouter
+from rest_framework.routers import SimpleRouter, DefaultRouter  # noqa: F401
 
 
 class LookupMixin(object):
@@ -77,7 +77,7 @@ class NestedSimpleRouter(SimpleRouter):
             parent_lookup_regex=parent_lookup_regex
         )
         if hasattr(parent_router, 'parent_regex'):
-            self.parent_regex = parent_router.parent_regex+self.parent_regex
+            self.parent_regex = parent_router.parent_regex + self.parent_regex
 
         for route in self.routes:
             route_contents = route._asdict()
@@ -86,7 +86,7 @@ class NestedSimpleRouter(SimpleRouter):
             # to escape it
             escaped_parent_regex = self.parent_regex.replace('{', '{{').replace('}', '}}')
 
-            route_contents['url'] = route.url.replace('^', '^'+escaped_parent_regex)
+            route_contents['url'] = route.url.replace('^', '^' + escaped_parent_regex)
             nested_routes.append(type(route)(**route_contents))
 
         self.routes = nested_routes

--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -28,6 +28,7 @@ Example:
 from __future__ import unicode_literals
 
 from rest_framework.routers import SimpleRouter, DefaultRouter  # noqa: F401
+from rest_framework.urlpatterns import format_suffix_patterns
 
 
 class LookupMixin(object):
@@ -39,6 +40,8 @@ class LookupMixin(object):
 
 
 class NestedSimpleRouter(SimpleRouter):
+    include_format_suffixes = True
+
     def __init__(self, parent_router, parent_prefix, *args, **kwargs):
         """ Create a NestedSimpleRouter nested within `parent_router`
         Args:
@@ -90,3 +93,11 @@ class NestedSimpleRouter(SimpleRouter):
             nested_routes.append(type(route)(**route_contents))
 
         self.routes = nested_routes
+
+    def get_urls(self):
+        urls = super(NestedSimpleRouter, self).get_urls()
+
+        if self.include_format_suffixes:
+            urls = format_suffix_patterns(urls)
+
+        return urls

--- a/rest_framework_nested/runtests/runcoverage.py
+++ b/rest_framework_nested/runtests/runcoverage.py
@@ -8,12 +8,11 @@ Useful tool to run the test suite for rest_framework and generate a coverage rep
 # http://code.djangoproject.com/svn/django/trunk/tests/runtests.py
 import os
 import sys
+from coverage import coverage
 
 # fix sys path so we don't need to setup PYTHONPATH
 sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'rest_framework_nested.runtests.settings'
-
-from coverage import coverage
 
 
 def main():
@@ -75,5 +74,6 @@ def main():
     sys.exit(failures)
 
 if __name__ == '__main__':
-    import ipdb;ipdb.set_trace()
+    import ipdb
+    ipdb.set_trace()
     main()

--- a/rest_framework_nested/runtests/runtests.py
+++ b/rest_framework_nested/runtests/runtests.py
@@ -27,7 +27,8 @@ def usage():
 
 def main():
     TestRunner = get_runner(settings)
-    import ipdb;ipdb.set_trace()
+    import ipdb
+    ipdb.set_trace()
 
     test_runner = TestRunner()
     if len(sys.argv) == 2:

--- a/rest_framework_nested/runtests/settings.py
+++ b/rest_framework_nested/runtests/settings.py
@@ -14,7 +14,7 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': 'django.db.backends.sqlite3',  # 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3', 'oracle'.
         'NAME': 'sqlite.db',                     # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
@@ -68,7 +68,7 @@ SECRET_KEY = 'u@x-aj9(hoh#rb-^ymf#g2jx_hp0vj7u5#b@ag1n^seu9e!%cy'
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
+    # 'django.template.loaders.eggs.Loader',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -97,15 +97,15 @@ INSTALLED_APPS = (
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
-    #'rest_framework.authtoken',
+    # 'rest_framework.authtoken',
     'rest_framework_nested',
     'rest_framework_nested.tests',
 )
 
 # OAuth is optional and won't work if there is no oauth_provider & oauth2
 try:
-    import oauth_provider
-    import oauth2
+    import oauth_provider  # noqa: F401
+    import oauth2  # noqa: F401
 except ImportError:
     pass
 else:
@@ -114,7 +114,7 @@ else:
     )
 
 try:
-    import provider
+    import provider  # noqa: F401
 except ImportError:
     pass
 else:
@@ -125,13 +125,13 @@ else:
 
 # guardian is optional
 try:
-    import guardian
+    import guardian  # noqa: F401
 except ImportError:
     pass
 else:
     ANONYMOUS_USER_ID = -1
     AUTHENTICATION_BACKENDS = (
-        'django.contrib.auth.backends.ModelBackend', # default
+        'django.contrib.auth.backends.ModelBackend',  # default
         'guardian.backends.ObjectPermissionBackend',
     )
     INSTALLED_APPS += (

--- a/rest_framework_nested/runtests/urls.py
+++ b/rest_framework_nested/runtests/urls.py
@@ -3,5 +3,4 @@ Blank URLConf just to keep runtests.py happy.
 """
 from rest_framework.compat import patterns
 
-urlpatterns = patterns('',
-)
+urlpatterns = patterns('',)

--- a/rest_framework_nested/serializers.py
+++ b/rest_framework_nested/serializers.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ImproperlyConfigured
 import rest_framework.serializers
 from rest_framework_nested.relations import NestedHyperlinkedIdentityField
 try:
@@ -21,13 +22,28 @@ class NestedHyperlinkedModelSerializer(rest_framework.serializers.HyperlinkedMod
     parent_lookup_field = 'parent'
     parent_lookup_related_field = 'pk'
     parent_lookup_url_kwarg = 'parent_pk'
+    parent_lookup_kwargs = {}
 
     serializer_url_field = NestedHyperlinkedIdentityField
 
     def __init__(self, *args, **kwargs):
-        self.parent_lookup_field = kwargs.pop('parent_lookup_field', self.parent_lookup_field)
-        self.parent_lookup_related_field = kwargs.pop('parent_lookup_related_field', self.parent_lookup_related_field)
-        self.parent_lookup_url_kwarg = kwargs.pop('parent_lookup_url_kwarg', self.parent_lookup_url_kwarg)
+        # check that config parameters are not mixed
+        if 'parent_lookup_kwargs' in kwargs and \
+                ('parent_lookup_field' in kwargs or 'parent_lookup_related_field' in kwargs
+                 or 'parent_lookup_url_kwarg' in kwargs):
+            raise ImproperlyConfigured("Do not mix parent_lookup_kwargs with any of the following: "
+                                       "parent_lookup_field, parent_lookup_related_field, parent_lookup_url_kwarg")
+
+        if 'parent_lookup_kwargs' in kwargs:
+            self.parent_lookup_kwargs = kwargs.pop('parent_lookup_kwargs', self.parent_lookup_kwargs)
+            self.parent_lookup_field = None
+            self.parent_lookup_related_field = None
+            self.parent_lookup_url_kwarg = None
+        else:
+            self.parent_lookup_kwargs = None
+            self.parent_lookup_field = kwargs.pop('parent_lookup_field', self.parent_lookup_field)
+            self.parent_lookup_related_field = kwargs.pop('parent_lookup_related_field', self.parent_lookup_related_field)
+            self.parent_lookup_url_kwarg = kwargs.pop('parent_lookup_url_kwarg', self.parent_lookup_url_kwarg)
 
         return super(NestedHyperlinkedModelSerializer, self).__init__(*args, **kwargs)
 
@@ -39,6 +55,7 @@ class NestedHyperlinkedModelSerializer(rest_framework.serializers.HyperlinkedMod
         field_kwargs['parent_lookup_field'] = self.parent_lookup_field
         field_kwargs['parent_lookup_related_field'] = self.parent_lookup_related_field
         field_kwargs['parent_lookup_url_kwarg'] = self.parent_lookup_url_kwarg
+        field_kwargs['parent_lookup_kwargs'] = self.parent_lookup_kwargs
 
         return field_class, field_kwargs
 

--- a/rest_framework_nested/serializers.py
+++ b/rest_framework_nested/serializers.py
@@ -3,8 +3,9 @@ from rest_framework_nested.relations import NestedHyperlinkedIdentityField
 try:
     from rest_framework.utils.field_mapping import get_nested_relation_kwargs
 except ImportError:
-    pass # passing because NestedHyperlinkedModelSerializer can't be used anyway
-         #    if version too old.
+    pass
+    # passing because NestedHyperlinkedModelSerializer can't be used anyway
+    #    if version too old.
 
 
 class NestedHyperlinkedModelSerializer(rest_framework.serializers.HyperlinkedModelSerializer):
@@ -31,7 +32,10 @@ class NestedHyperlinkedModelSerializer(rest_framework.serializers.HyperlinkedMod
         return super(NestedHyperlinkedModelSerializer, self).__init__(*args, **kwargs)
 
     def build_url_field(self, field_name, model_class):
-        field_class, field_kwargs = super(NestedHyperlinkedModelSerializer, self).build_url_field(field_name, model_class)
+        field_class, field_kwargs = super(NestedHyperlinkedModelSerializer, self).build_url_field(
+            field_name,
+            model_class
+        )
         field_kwargs['parent_lookup_field'] = self.parent_lookup_field
         field_kwargs['parent_lookup_related_field'] = self.parent_lookup_related_field
         field_kwargs['parent_lookup_url_kwarg'] = self.parent_lookup_url_kwarg

--- a/rest_framework_nested/serializers.py
+++ b/rest_framework_nested/serializers.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ImproperlyConfigured
 import rest_framework.serializers
 from rest_framework_nested.relations import NestedHyperlinkedIdentityField
 try:
@@ -19,42 +18,21 @@ class NestedHyperlinkedModelSerializer(rest_framework.serializers.HyperlinkedMod
 
     NOTE: this only works with DRF 3.1.0 and above.
     """
-    parent_lookup_field = 'parent'
-    parent_lookup_related_field = 'pk'
-    parent_lookup_url_kwarg = 'parent_pk'
-    parent_lookup_kwargs = {}
+    parent_lookup_kwargs = {
+        'parent_pk': 'parent__pk'
+    }
 
     serializer_url_field = NestedHyperlinkedIdentityField
 
     def __init__(self, *args, **kwargs):
-        # check that config parameters are not mixed
-        if 'parent_lookup_kwargs' in kwargs and \
-                ('parent_lookup_field' in kwargs or 'parent_lookup_related_field' in kwargs
-                 or 'parent_lookup_url_kwarg' in kwargs):
-            raise ImproperlyConfigured("Do not mix parent_lookup_kwargs with any of the following: "
-                                       "parent_lookup_field, parent_lookup_related_field, parent_lookup_url_kwarg")
-
-        if 'parent_lookup_kwargs' in kwargs:
-            self.parent_lookup_kwargs = kwargs.pop('parent_lookup_kwargs', self.parent_lookup_kwargs)
-            self.parent_lookup_field = None
-            self.parent_lookup_related_field = None
-            self.parent_lookup_url_kwarg = None
-        else:
-            self.parent_lookup_kwargs = None
-            self.parent_lookup_field = kwargs.pop('parent_lookup_field', self.parent_lookup_field)
-            self.parent_lookup_related_field = kwargs.pop('parent_lookup_related_field', self.parent_lookup_related_field)
-            self.parent_lookup_url_kwarg = kwargs.pop('parent_lookup_url_kwarg', self.parent_lookup_url_kwarg)
-
-        return super(NestedHyperlinkedModelSerializer, self).__init__(*args, **kwargs)
+        self.parent_lookup_kwargs = kwargs.pop('parent_lookup_kwargs', self.parent_lookup_kwargs)
+        super(NestedHyperlinkedModelSerializer, self).__init__(*args, **kwargs)
 
     def build_url_field(self, field_name, model_class):
         field_class, field_kwargs = super(NestedHyperlinkedModelSerializer, self).build_url_field(
             field_name,
             model_class
         )
-        field_kwargs['parent_lookup_field'] = self.parent_lookup_field
-        field_kwargs['parent_lookup_related_field'] = self.parent_lookup_related_field
-        field_kwargs['parent_lookup_url_kwarg'] = self.parent_lookup_url_kwarg
         field_kwargs['parent_lookup_kwargs'] = self.parent_lookup_kwargs
 
         return field_class, field_kwargs

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     package_data=get_package_data(package),
     install_requires=[
         'djangorestframework>=2.4.3',
-        'Django>=1.6',
+        'Django>=1.8',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -92,6 +92,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tests/serializers/models.py
+++ b/tests/serializers/models.py
@@ -42,9 +42,8 @@ class ParentChild1Serializer(nested_serializers.NestedHyperlinkedModelSerializer
 
 class ParentChild2GrandChild1Serializer(nested_serializers.NestedHyperlinkedModelSerializer):
     parent_lookup_kwargs = {
-        'pk': 'pk',
         'parent_pk': 'parent__pk',
-        'root_pk': 'parent__root__pk'
+        'root_pk': 'parent__root__pk',
     }
 
     class Meta:
@@ -53,8 +52,9 @@ class ParentChild2GrandChild1Serializer(nested_serializers.NestedHyperlinkedMode
 
 
 class ParentChild2Serializer(nested_serializers.NestedHyperlinkedModelSerializer):
-    parent_lookup_url_kwarg = 'root_pk'
-    parent_lookup_field = 'root'
+    parent_lookup_kwargs = {
+        'root_pk': 'root__pk',
+    }
 
     class Meta:
         model = Child2

--- a/tests/serializers/models.py
+++ b/tests/serializers/models.py
@@ -17,6 +17,11 @@ class Child2(models.Model):
     root = models.ForeignKey(Parent, related_name='second')
 
 
+class GrandChild1(models.Model):
+    name = models.CharField(max_length=10)
+    parent = models.ForeignKey(Child2, related_name='grand')
+
+
 class Child1Serializer(serializers.ModelSerializer):
     class Meta:
         model = Child1
@@ -35,13 +40,34 @@ class ParentChild1Serializer(nested_serializers.NestedHyperlinkedModelSerializer
         fields = ('url', 'name')
 
 
+class ParentChild2GrandChild1Serializer(nested_serializers.NestedHyperlinkedModelSerializer):
+    parent_lookup_kwargs = {
+        'pk': 'pk',
+        'parent_pk': 'parent__pk',
+        'root_pk': 'parent__root__pk'
+    }
+
+    class Meta:
+        model = GrandChild1
+        fields = ('url', 'name')
+
+
 class ParentChild2Serializer(nested_serializers.NestedHyperlinkedModelSerializer):
     parent_lookup_url_kwarg = 'root_pk'
     parent_lookup_field = 'root'
 
     class Meta:
         model = Child2
-        fields = ('url', 'name')
+        fields = ('url', 'name', 'grand')
+
+    grand = ParentChild2GrandChild1Serializer(
+        many=True, read_only=True,
+        parent_lookup_kwargs={
+            'pk': 'pk',
+            'parent_pk': 'parent__pk',
+            'root_pk': 'parent__root__pk'
+        }
+    )
 
 
 class Parent1Serializer(serializers.ModelSerializer):
@@ -78,3 +104,8 @@ class Child1Viewset(viewsets.ModelViewSet):
 class Child2Viewset(viewsets.ModelViewSet):
     serializer_class = Child2Serializer
     queryset = Child2.objects.all()
+
+
+class ParentChild2GrandChild1Viewset(viewsets.ModelViewSet):
+    serializer_class = ParentChild2GrandChild1Serializer
+    queryset = GrandChild1.objects.all()

--- a/tests/serializers/test_serializers.py
+++ b/tests/serializers/test_serializers.py
@@ -15,7 +15,7 @@ class TestSerializers(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        drf = pytest.importorskip("rest_framework", minversion="3.1.0")
+        pytest.importorskip("rest_framework", minversion="3.1.0")
         parent = Parent.objects.create(name='Parent')
 
         Child1.objects.create(parent=parent, name='Child1-A')

--- a/tests/serializers/test_serializers.py
+++ b/tests/serializers/test_serializers.py
@@ -3,7 +3,7 @@ import pytest
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-from tests.serializers.models import Parent, Child1, Child2
+from tests.serializers.models import Parent, Child1, Child2, GrandChild1
 
 
 class TestSerializers(TestCase):
@@ -22,9 +22,14 @@ class TestSerializers(TestCase):
         Child1.objects.create(parent=parent, name='Child1-B')
         Child1.objects.create(parent=parent, name='Child1-C')
 
-        Child2.objects.create(root=parent, name='Child2-A')
+        child2 = Child2.objects.create(root=parent, name='Child2-A')
         Child2.objects.create(root=parent, name='Child2-B')
         Child2.objects.create(root=parent, name='Child2-C')
+
+        GrandChild1.objects.create(parent=child2, name='Child2-GrandChild1-A')
+        GrandChild1.objects.create(parent=child2, name='Child2-GrandChild1-B')
+        GrandChild1.objects.create(parent=child2, name='Child2-GrandChild1-C')
+
 
         Parent.objects.create(name='Parent2')
         return super(TestSerializers, cls).setUpClass()
@@ -40,7 +45,6 @@ class TestSerializers(TestCase):
         self.assertIn('/parent1/1/child1/3/', data['first'][2]['url'])
 
     def test_custom(self):
-        return
         url = reverse('parent2-detail', kwargs={'pk': 1})
         data = self.get_json_response(url)
 

--- a/tests/serializers/urls.py
+++ b/tests/serializers/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url, include
 from rest_framework_nested import routers
 
-from tests.serializers.models import Parent1Viewset, Child1Viewset, Parent2Viewset, Child2Viewset
+from tests.serializers.models import Parent1Viewset, Child1Viewset, Parent2Viewset, Child2Viewset, ParentChild2GrandChild1Viewset
 
 
 router_1 = routers.SimpleRouter()
@@ -14,9 +14,13 @@ router_2.register('parent2', Parent2Viewset, base_name='parent2')
 parent_2_router = routers.NestedSimpleRouter(router_2, r'parent2', lookup='root')
 parent_2_router.register(r'child2', Child2Viewset, base_name='child2')
 
+parent_2_grandchild_router = routers.NestedSimpleRouter(parent_2_router, r'child2', lookup='parent')
+parent_2_grandchild_router.register(r'grandchild1', ParentChild2GrandChild1Viewset, base_name='grandchild1')
+
 urlpatterns = [
     url(r'^', include(router_1.urls)),
     url(r'^', include(parent_1_router.urls)),
     url(r'^', include(router_2.urls)),
     url(r'^', include(parent_2_router.urls)),
+    url(r'^', include(parent_2_grandchild_router.urls)),
 ]

--- a/tests/test_dynamic_routers.py
+++ b/tests/test_dynamic_routers.py
@@ -12,8 +12,10 @@ from rest_framework.response import Response
 
 QS = namedtuple('Queryset', ['model'])
 
+
 class BasicModel(models.Model):
-    name=models.CharField(max_length=255)
+    name = models.CharField(max_length=255)
+
     class Meta:
         app_label = 'testapp'
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -13,26 +13,34 @@ QS = namedtuple('Queryset', ['model'])
 
 
 class A(models.Model):
-    name=models.CharField(max_length=255)
+    name = models.CharField(max_length=255)
+
+
 class B(models.Model):
-    name=models.CharField(max_length=255)
-    parent=models.ForeignKey(A)
+    name = models.CharField(max_length=255)
+    parent = models.ForeignKey(A)
+
+
 class C(models.Model):
-    name=models.CharField(max_length=255)
-    parent=models.ForeignKey(B)
+    name = models.CharField(max_length=255)
+    parent = models.ForeignKey(B)
+
 
 class AViewSet(ModelViewSet):
     lookup_value_regex = '[0-9a-f]{32}'
     model = A
     queryset = QS(A)
 
+
 class BViewSet(ModelViewSet):
     model = B
     queryset = QS(B)
 
+
 class CViewSet(ModelViewSet):
     model = C
     queryset = QS(C)
+
 
 class TestNestedSimpleRouter(TestCase):
     def setUp(self):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,3 @@
-from django.conf.urls import url, include
-
 from tests.serializers.urls import urlpatterns as serializers_urls
 
 urlpatterns = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,26 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34,py35}-django{1.6,1.7,1.8,1.9,1.10}-drf{2.4,3.0,3.1,3.3,3.5}
+       {py27,py33,py34,py35,py36}-django{1.8}-drf{2.4,3.0},
+       {py27,py33,py34,py35,py36}-django{1.9}-drf{3.1,3.2,3.3,3.4,3.5}
+       {py27,py33,py34,py35,py36}-django{1.10}-drf{3.3,3.4,3.5}
+
 
 [testenv]
 commands = ./runtests.py --nolint
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.6: Django==1.6.11
-       django1.7: Django==1.7.8
-       django1.8: Django==1.8
-       django1.9: Django==1.9
-       django1.10: Django==1.10.3
-       drf2.4: djangorestframework==2.4.4
-       drf3.0: djangorestframework==3.0.5
-       drf3.1: djangorestframework==3.1.3
-       drf3.3: djangorestframework==3.3.3
-       drf3.5: djangorestframework==3.5.3
+       django1.8: Django>=1.8,<1.9
+       django1.9: Django>=1.9,<1.10
+       django1.10: Django>=1.10,<1.11
+       drf2.4: djangorestframework>=2.4,<2.5
+       drf3.0: djangorestframework>=3.0,<3.1
+       drf3.1: djangorestframework>=3.1,<3.2
+       drf3.2: djangorestframework>=3.2,<3.3
+       drf3.3: djangorestframework>=3.3,<3.4
+       drf3.4: djangorestframework>=3.4,<3.5
+       drf3.5: djangorestframework>=3.5,<3.6
        pytest-django==2.8.0
        -rrequirements-tox.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
        py27-{flake8,docs},
        {py27,py33,py34,py35,py36}-django{1.8}-drf{2.4,3.0},
-       {py27,py33,py34,py35,py36}-django{1.9}-drf{3.1,3.2,3.3,3.4,3.5}
-       {py27,py33,py34,py35,py36}-django{1.10}-drf{3.3,3.4,3.5}
+       {py27,py34,py35,py36}-django{1.9}-drf{3.1,3.2,3.3,3.4,3.5}
+       {py27,py34,py35,py36}-django{1.10}-drf{3.3,3.4,3.5}
 
 
 [testenv]


### PR DESCRIPTION
Bunch of things in a single PR to get us to a new release.  I did it this way so that when Travis is green you can just merge, bump the version number, deploy.

## Other Changes
- Flake 8 passing for everything
- Cleaned up versions of Django and DRF that we test against.  When I run `tox` locally I was getting errors thrown from inside DRF itself.
- Change `Travis` to use `tox-travis` plugin to reduce the duplication between the two config files.

## Issue Related Changes
- Cleans up and closes #88 
I pulled in @ChristianKreuzberger PR to give credit where credit is due, and then changed things based on the discussion in that PR.  I actually made the tests run (my fault) and added a test specifically for his changes.

- Cleans up and closes #71 
I pulled in @Symmetric PR to give credit where credit is due, but the next commit changed everything 😄 . Rather than everything being in NestedSimpleRouter, moved our work into a Mixin so we could easily have NestedSimpleRouter and NestedDefaultRouter without duplicating and without making a strange amalgamation of SimpleRouter and DefaultRouter

In my opinion, we should just close #72. The example given was:
```python
router = SimpleRouter()
router.register(r'endpoint', AViewSet, base_name='api-myviewset')
sub_router = NestedSimpleRouter(router, r'sub', lookup="id")
sub_router.register(r'sub', AnotherViewSet, base_name='api-myviewset-sub')
```
But the 2nd param of `NestedSimpleRouter` is the parent prefix so it should be:
```python
router = SimpleRouter()
router.register(r'endpoint', AViewSet, base_name='api-myviewset')
sub_router = NestedSimpleRouter(router, r'endpoint', lookup="id")
sub_router.register(r'sub', AnotherViewSet, base_name='api-myviewset-sub')
```
which works.

