### PR TITLE
Router doesn't work if prefix is blank but project urls.py handles prefix

### DIFF
--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -63,6 +63,12 @@ class NestedMixin(object):
             parent_prefix=parent_prefix,
             parent_lookup_regex=parent_lookup_regex
         )
+        # If there is no parent prefix, the first part of the url is probably
+        #   controlled by the project's urls.py and the router is in an app,
+        #   so a slash in the beginning will (A) cause Django to give warnings
+        #   and (B) generate URLs that will require using `//`
+        if not self.parent_prefix and self.parent_regex[0] == '/':
+            self.parent_regex = self.parent_regex[1:]
         if hasattr(parent_router, 'parent_regex'):
             self.parent_regex = parent_router.parent_regex + self.parent_regex
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -2,7 +2,6 @@
 based upon https://github.com/alanjds/drf-nested-routers/issues/15
 """
 from collections import namedtuple
-
 from django.db import models
 from django.test import TestCase
 from rest_framework.viewsets import ModelViewSet
@@ -69,3 +68,18 @@ class TestNestedSimpleRouter(TestCase):
         self.assertEquals(len(urls), 2)
         self.assertEquals(urls[0].regex.pattern, u'^a/(?P<a_pk>[0-9a-f]{32})/b/(?P<b_pk>[^/.]+)/c/$')
         self.assertEquals(urls[1].regex.pattern, u'^a/(?P<a_pk>[0-9a-f]{32})/b/(?P<b_pk>[^/.]+)/c/(?P<pk>[^/.]+)/$')
+
+
+class TestEmptyPrefix(TestCase):
+    def setUp(self):
+        self.router = SimpleRouter()
+        self.router.register(r'', AViewSet)
+        self.a_router = NestedSimpleRouter(self.router, r'', lookup='a')
+        self.a_router.register(r'b', BViewSet)
+
+    def test_empty_prefix(self):
+        urls = self.router.urls
+        urls = self.a_router.urls
+        self.assertEquals(len(urls), 2)
+        self.assertEquals(urls[0].regex.pattern, u'^(?P<a_pk>[0-9a-f]{32})/b/$')
+        self.assertEquals(urls[1].regex.pattern, u'^(?P<a_pk>[0-9a-f]{32})/b/(?P<pk>[^/.]+)/$')


### PR DESCRIPTION
DRF had similiar issue and I hoped it would cascade down, but for the
nested varieties, we need to fix in a different spot.

If your setup is like
```
# projects urls.py
urlpattern = [
	url(r'^foo/', include('foo.urls'))
]

# foo's urls.py
router = routers.SimpleRouter()
router.register(r'', viewsets.FooViewSet)

sub_fouter = routers.NestedSimpleRouter(router, '', lookup='foo')
sub_router.register('subfoo', viewsets.SubFooViewSet)

urlpatterns = [
	url(r'^', include(router.urls))
	url(r'^', include(sub_router.urls))
]
```
The url pattern for the sub_router will have '^/' which causes the
actual url be '/foo//subfoo/' which nobody wants.