### PR TITLE
Fix nested multi-level lookups

### DIFF
--- a/rest_framework_nested/relations.py
+++ b/rest_framework_nested/relations.py
@@ -58,6 +58,9 @@ class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedF
 
         return self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
+    def use_pk_only_optimization(self):
+        return False
+
     def get_object(self, view_name, view_args, view_kwargs):
         """
         Return the object corresponding to a matched URL.
@@ -73,9 +76,9 @@ class NestedHyperlinkedRelatedField(rest_framework.relations.HyperlinkedRelatedF
         # multi-level lookup
         for parent_lookup_kwarg in list(self.parent_lookup_kwargs.keys()):
             lookup_value = view_kwargs[parent_lookup_kwarg]
-            kwargs.update({parent_lookup_kwarg: lookup_value})
+            kwargs.update({self.parent_lookup_kwargs[parent_lookup_kwarg]: lookup_value})
 
-            return self.get_queryset().get(**kwargs)
+        return self.get_queryset().get(**kwargs)
 
 
 class NestedHyperlinkedIdentityField(NestedHyperlinkedRelatedField):
@@ -84,6 +87,3 @@ class NestedHyperlinkedIdentityField(NestedHyperlinkedRelatedField):
         kwargs['read_only'] = True
         kwargs['source'] = '*'
         super(NestedHyperlinkedIdentityField, self).__init__(view_name=view_name, **kwargs)
-
-    def use_pk_only_optimization(self):
-        return False

--- a/tests/serializers/models.py
+++ b/tests/serializers/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from rest_framework import serializers, viewsets
 from rest_framework_nested import serializers as nested_serializers
+from rest_framework_nested import relations
 
 
 class Parent(models.Model):
@@ -45,10 +46,12 @@ class ParentChild2GrandChild1Serializer(nested_serializers.NestedHyperlinkedMode
         'parent_pk': 'parent__pk',
         'root_pk': 'parent__root__pk',
     }
+    parent = relations.NestedHyperlinkedRelatedField(parent_lookup_kwargs={'root_pk': 'root__pk'},
+                                                     view_name='child2-detail', queryset=Child2.objects.all())
 
     class Meta:
         model = GrandChild1
-        fields = ('url', 'name')
+        fields = ('url', 'name', 'parent')
 
 
 class ParentChild2Serializer(nested_serializers.NestedHyperlinkedModelSerializer):


### PR DESCRIPTION
When trying to use nested multi-level lookups in my application, I encountered a couple of issues with it.
Initially, there was this error:
```
Exception Type: FieldError at /api/enrollments/studies/
Exception Value: Cannot resolve keyword 'faculty_pk' into field. Choices are:  faculty, faculty_id, id
```

I think this error occurs because of `kwargs.update({parent_lookup_kwarg: lookup_value})`:
Instead of mapping the view kwarg to a queryset kwarg, the view kwarg is inserted here.

After fixing this issue, I got another error:
```
Exception Type: AttributeError at /api/enrollments/studies/
Exception Value: 'PKOnlyObject' object has no attribute 'faculty'
```
Because the rest framework `HyperlinkedRelatedField` enables an optimization when its `lookup_field == 'pk'` (the default), only that field is available, and the models being referred to with a foreign key are not available. So I disabled pk optimizations (like `NestedHyperlinkedIdentityField` already does).

Finally, I noticed that the return happens from inside the multi-level lookup loop, which seems like an error to me.

Since I'm quite new to django & the rest framework, it is possible I am completely wrong and my code is the problem. I tried my best to provide the minimal code that caused my issues below, so you can evaluate whether these issues are caused by a bug in this library, or in my code.

Models:
```python
class StudyEnrollment(models.Model):
    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=False)
    study = models.ForeignKey('Study', on_delete=models.CASCADE, null=False)

class Study(models.Model):
    enrollments = models.ManyToManyField(settings.AUTH_USER_MODEL, through=StudyEnrollment,
                                         related_name='studies')
```
Serializer:
```python
class StudyEnrollmentSerializer(serializers.ModelSerializer):
    study = NestedHyperlinkedRelatedField(parent_lookup_kwargs={'faculty_pk': 'faculty__pk'},
                                          queryset=Study.objects.all(),
                                          view_name='study-detail')
    class Meta:
        model = StudyEnrollment
        fields = ('study',)
```

Router:
```python
api_router = DefaultRouter()
api_router.register(r'faculties', vectors.syllabus.views.FacultyViewSet)
faculty_router = NestedDefaultRouter(api_router, r'faculties', lookup='faculty')
faculty_router.register(r'studies', vectors.syllabus.views.StudyViewSet)
```

And this piece of code in a `ModelViewSet`
```python
serializer = StudyEnrollmentSerializer(data=request.data, many=True, context=self.get_serializer_context())
serializer.is_valid(raise_exception=True)
serializer.save()
```