### PR TITLE
Expand Travis matrix w/ minimum duplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,20 @@ python:
   - "3.5"
   - "3.6"
 env:
-  - DJANGO="1.8"
-  - DJANGO="1.9"
-  - DJANGO="1.10"
-  - DJANGO="1.11"
-  - DRF="2.4"
-  - DRF="3.0"
-  - DRF="3.1"
-  - DRF="3.2"
-  - DRF="3.3"
-  - DRF="3.4"
-  - DRF="3.5"
-  - DRF="3.6"
+  global:
+    - DJANGO="1.8"
+    - DJANGO="1.9"
+    - DJANGO="1.10"
+    - DJANGO="1.11"
+  matrix:
+    - DRF="2.4"
+    - DRF="3.0"
+    - DRF="3.1"
+    - DRF="3.2"
+    - DRF="3.3"
+    - DRF="3.4"
+    - DRF="3.5"
+    - DRF="3.6"
 
 install: pip install tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,19 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+env:
+  - DJANGO="1.8"
+  - DJANGO="1.9"
+  - DJANGO="1.10"
+  - DJANGO="1.11"
+  - DRF="2.4"
+  - DRF="3.0"
+  - DRF="3.1"
+  - DRF="3.2"
+  - DRF="3.3"
+  - DRF="3.4"
+  - DRF="3.5"
+  - DRF="3.6"
 
 install: pip install tox-travis
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,25 @@
 envlist =
        py27-{flake8,docs},
        {py27,py33,py34,py35,py36}-django{1.8}-drf{2.4,3.0},
-       {py27,py34,py35,py36}-django{1.9}-drf{3.1,3.2,3.3,3.4,3.5}
+       {py27,py34,py35,py36}-django{1.9}-drf{3.1,3.2,3.3,3.4,3.5,3.6}
        {py27,py34,py35,py36}-django{1.10}-drf{3.3,3.4,3.5,3.6}
-       {py27,py34,py35,py36}-django{1.11}-drf{3.6}
+       {py27,py34,py35,py36}-django{1.11}-drf{3.3,3.4,3.5,3.6}
 
+[travis:env]
+DJANGO =
+       1.8: django1.8
+       1.9: django1.9
+       1.10: django1.10
+       1.11: django1.11
+DRF =
+       2.4: drf2.4
+       3.0: drf3.0
+       3.1: drf3.1
+       3.2: drf3.2
+       3.3: drf3.3
+       3.4: drf3.4
+       3.5: drf3.5
+       3.6: drf3.6
 
 [testenv]
 commands = ./runtests.py --nolint
@@ -15,7 +30,7 @@ deps =
        django1.8: Django>=1.8,<1.9
        django1.9: Django>=1.9,<1.10
        django1.10: Django>=1.10,<1.11
-       django1.11: Django>=1.11,<2.0
+       django1.11: Django>=1.11,<1.12
        drf2.4: djangorestframework>=2.4,<2.5
        drf3.0: djangorestframework>=3.0,<3.1
        drf3.1: djangorestframework>=3.1,<3.2


### PR DESCRIPTION
Before the change I made in
https://github.com/alanjds/drf-nested-routers/commit/eb4f443230abfefd2c3a065abe1d7dc3cc02cb25,
we had Travis doing a lot of parallel tests (a good thing) but the
matrix had to be defined in both Travis and Tox (a bad thing).  After
that commit, the matrix was only in Tox (a good thing) but it cut down
on the parallel testing in Travis (a bad thing).

This commit is an attempt to balance the two things.  Tox is still the
holder of the overall matrix but we duplicate a minimal amount of
information to travis to get more jobs running at once.

I can't really test this locally nor on my own fork (unless I signup 
for Travis personally), so this PR is *DEFINITELY* a WIP.