### PR TITLE
Fix doc glitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ class DomainSerializer(HyperlinkedModelSerializer):
         many=True,
         read_only=True,   # Or add a queryset
         view_name='domain-nameservers-detail'
-        parent_lookup_url_kwargs={'domain_pk': 'domain__pk'}
+        parent_lookup_kwargs={'domain_pk': 'domain__pk'}
     )
 ```
 


### PR DESCRIPTION
`parent_lookup_url_kwargs` is old nomenclature, the new hotness is `parent_lookup_kwargs`