### PR TITLE
Inherit trailing_slash attribute from parent router

### DIFF
--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -54,6 +54,22 @@ class NestedMixin(object):
 
         super(NestedMixin, self).__init__(*args, **kwargs)
 
+        if 'trailing_slash' not in kwargs:
+            # Inherit trailing_slash only when not specified explicitly.
+            #
+            # drf transposes the trailing_slash argument into the actual appended value
+            # within the route urls. This means that, on the parent class, trailing_slash
+            # is either '/' or '' for the expected kwarg values True or False, respectively.
+            # If, however, the trailing_slash property has been further customized beyond
+            # those two values (for example, to add an optional slash with '/?'), we won't
+            # be able to set it through the kwargs.
+            #
+            # By copying the value of trailing_slash directly, we ensure that our inherited
+            # behavior is ALWAYS consistent with the parent. If we didn't, we might create
+            # a situation where the parent's trailing slash is truthy (but not '/') and
+            # we set our trailing slash to just '/', leading to inconsistent behavior.
+            self.trailing_slash = parent_router.trailing_slash
+
         parent_registry = [registered for registered
                            in self.parent_router.registry
                            if registered[0] == self.parent_prefix]

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -10,6 +10,24 @@ from rest_framework_nested.routers import SimpleRouter, NestedSimpleRouter
 from tests.helpers import get_regex_pattern
 
 
+def pattern_from_url(url_pattern):
+    """
+    Finds the internal stringified pattern for a URL across
+    Django versions.
+
+    Newer versions of Django use URLPattern, as opposed to
+    RegexURLPattern.
+    """
+    if hasattr(url_pattern, 'pattern'):
+        pattern = str(url_pattern.pattern)
+    elif hasattr(url_pattern._regex, 'pattern'):
+        pattern = str(url_pattern.regex.pattern)
+    else:
+        pattern = url_pattern._regex
+
+    return pattern
+
+
 QS = namedtuple('Queryset', ['model'])
 
 
@@ -96,3 +114,90 @@ class TestBadLookupValue(TestCase):
         with self.assertRaises(ValueError):
             self.a_router = NestedSimpleRouter(self.router, r'parents', lookup='ui-parent_2')
             self.a_router.register(r'child', BViewSet, base_name='ui-parent-child')
+
+
+class TestRouterSettingInheritance(TestCase):
+    """
+    Ensure that nested routers inherit the trailing_slash option from
+    their parent unless explicitly told not to.
+
+    note: drf transforms the boolean from the kwargs into an internal
+    pattern string, so it required to test these values instead of
+    the boolean.
+
+        trailing_slash=True -> '/'
+        trailing_slash=False -> ''
+
+    trailing_slash should
+        - always give priority to the value explicitly defined on the router
+        - if inherited, use the trailing slash exactly as set in the parent
+    """
+
+    def _assertHasTrailingSlash(self, router):
+        self.assertEqual(router.trailing_slash, u'/', "router does not have trailing slash when it should")
+        self.assertTrue(pattern_from_url(router.urls[0]).endswith('/$'),
+                        "router created url without trailing slash when it should have")
+
+    def _assertDoesNotHaveTrailingSlash(self, router):
+        self.assertEqual(router.trailing_slash, u'', "router has trailing slash when it should not")
+        self.assertFalse(pattern_from_url(router.urls[0]).endswith('/$'),
+                         "router created url with trailing slash when it should not have")
+
+    def test_inherits_no_trailing_slash(self):
+        """
+        Test whether the trailing_slash=False value is inherited when it
+        is unspecified on the nested router.
+        """
+        router = SimpleRouter(trailing_slash=False)
+        router.register('a', AViewSet)
+        a_router = NestedSimpleRouter(router, 'a', lookup='a')
+        a_router.register('b', BViewSet)
+
+        self._assertDoesNotHaveTrailingSlash(a_router)
+
+    def test_inherits_trailing_slash(self):
+        """
+        Test whether the trailing_slash=False value is inherited when it
+        is unspecified on the nested router.
+        """
+        router = SimpleRouter(trailing_slash=True)
+        router.register('a', AViewSet)
+        a_router = NestedSimpleRouter(router, 'a', lookup='a')
+        a_router.register('b', BViewSet)
+
+        self._assertHasTrailingSlash(a_router)
+
+    def test_explicit_no_trailing_slash(self):
+        router = SimpleRouter(trailing_slash=True)
+        router.register('a', AViewSet)
+        a_router = NestedSimpleRouter(router, 'a', lookup='a', trailing_slash=False)
+        a_router.register('b', BViewSet)
+
+        self._assertDoesNotHaveTrailingSlash(a_router)
+
+    def test_explicit_trailing_slash(self):
+        """
+        Test whether the trailing_slash=False value is properly overridden when setting
+        trailing_slash=True on the nested router.
+        """
+        router = SimpleRouter(trailing_slash=False)
+        router.register('a', AViewSet)
+        a_router = NestedSimpleRouter(router, 'a', lookup='a', trailing_slash=True)
+        a_router.register('b', BViewSet)
+
+        self._assertHasTrailingSlash(a_router)
+
+    def test_inherits_nonstandard_trailing_slash(self):
+        """
+        Test whether the trailing_slash attribute, when set with a custom value,
+        is inherited by the nested routed.
+        """
+        router = SimpleRouter()
+        router.trailing_slash = '/?'
+        router.register('a', AViewSet)
+        a_router = NestedSimpleRouter(router, 'a', lookup='a')
+        a_router.register('b', BViewSet)
+
+        self.assertEqual(a_router.trailing_slash, u'/?', "router does not have trailing slash when it should")
+        self.assertTrue(pattern_from_url(a_router.urls[0]).endswith('/?$'),
+                        "router created url without trailing slash when it should have")


### PR DESCRIPTION
Resolves #115 

When `trailing_slash` is not explicitly given on a NestedRouter interface, we copy the `trailing_slash` attribute from the parent.

There is some care taken to avoid just passing a True or False into the parent constructer, because it limits the ability to inherit all possible values. (Plus it avoids the need to do a roundabout truthiness inspection on the parent's `trailing_slash`, because the external interface is boolean instead of the internal storage which is a string.)

Had to write a little helper for the tests because URLs change across Django versions. I think I caught all the cases that matter. (It passes tox tests for all django versions using py36, which is all i ran).