### PR TITLE
test for drf 3.10 

### DIFF
--- a/tests/test_dynamic_routers.py
+++ b/tests/test_dynamic_routers.py
@@ -32,13 +32,12 @@ try:
     def list_route_decorator(**kwargs):
         return action(detail=False, **kwargs)
 except ImportError:
-    pass
+    # for DRF < 3.8
+    try:
+        from rest_framework.decorators import detail_route as detail_route_decorator, list_route as list_route_decorator
+    except ImportError:
+        pass
 
-# for DRF < 3.8
-try:
-    from rest_framework.decorators import detail_route as detail_route_decorator, list_route as list_route_decorator
-except ImportError:
-    pass
 
 if 'detail_route_decorator' in globals() and 'list_route_decorator' in globals():
     def map_by_name(iterable):

--- a/tests/test_dynamic_routers.py
+++ b/tests/test_dynamic_routers.py
@@ -22,11 +22,25 @@ class BasicModel(models.Model):
         app_label = 'testapp'
 
 
+# DRF 3.8+
 try:
-    from rest_framework.decorators import detail_route, list_route
+    from rest_framework.decorators import action
+
+    def detail_route_decorator(**kwargs):
+        return action(detail=True, **kwargs)
+
+    def list_route_decorator(**kwargs):
+        return action(detail=False, **kwargs)
 except ImportError:
     pass
-else:
+
+# for DRF < 3.8
+try:
+    from rest_framework.decorators import detail_route as detail_route_decorator, list_route as list_route_decorator
+except ImportError:
+    pass
+
+if 'detail_route_decorator' in globals() and 'list_route_decorator' in globals():
     def map_by_name(iterable):
         ret = {}
         for item in iterable:
@@ -37,7 +51,7 @@ else:
         model = BasicModel
         queryset = QS(BasicModel)
 
-        @detail_route(methods=["post"])
+        @detail_route_decorator(methods=["post"])
         def set_password(self, request, pk=None):
             return Response({'hello': 'ok'})
 
@@ -45,7 +59,7 @@ else:
         model = BasicModel
         queryset = QS(BasicModel)
 
-        @list_route()
+        @list_route_decorator()
         def recent_users(self, request, pk=None):
             return Response([{'hello': 'ok'}])
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
        py27-{flake8,docs},
        {py27,py34}-django1.11-drf{3.6,3.7,3.8,3.9}
-       {py34,py35,py36,py37}-django1.11-drf{3.6,3.7,3.8,3.9,3.10}
+       {py35,py36,py37}-django1.11-drf{3.6,3.7,3.8,3.9,3.10}
        {py34}-django{2.0}-drf{3.7,3.8}
        {py35,py36,py37}-django{2.0,2.1,2.2}-drf{3.7,3.8,3.9,3.10}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py34,py35,py36}-django{1.11}-drf{3.6,3.7,3.8}
+       {py27,py34}-django1.11-drf{3.6,3.7,3.8,3.9}
+       {py34,py35,py36,py37}-django1.11-drf{3.6,3.7,3.8,3.9,3.10}
        {py34}-django{2.0}-drf{3.7,3.8}
-       {py35,py36,py37}-django{2.0,2.1,2.2}-drf{3.7,3.8,3.9}
+       {py35,py36,py37}-django{2.0,2.1,2.2}-drf{3.7,3.8,3.9,3.10}
 
 
 [testenv]
@@ -19,6 +20,7 @@ deps =
        drf3.7: djangorestframework>=3.7,<3.8
        drf3.8: djangorestframework>=3.8,<3.9
        drf3.9: djangorestframework>=3.9,<3.10
+       drf3.10: djangorestframework>=3.10,<3.11
        pytest-django==3.4.2
        -rrequirements-tox.txt
 


### PR DESCRIPTION
- DRF3.10 drops python2 support
https://github.com/encode/django-rest-framework/pull/6615

- DRF3.10 drops python3.4 support
https://github.com/encode/django-rest-framework/pull/6620

- as of 1.11.17, django is compatible with Python 3.7
https://docs.djangoproject.com/en/2.2/releases/1.11.17/

thus changed envlist

---

- list_route and detail_route was removed in DRF3.10
https://github.com/encode/django-rest-framework/pull/6687

needs change in `tests/test_dynamic_routers.py`