### PR TITLE
Rename `base_name` => `basename` for django-rest-framework compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ router = routers.SimpleRouter()
 router.register(r'domains', DomainViewSet)
 
 domains_router = routers.NestedSimpleRouter(router, r'domains', lookup='domain')
-domains_router.register(r'nameservers', NameserverViewSet, base_name='domain-nameservers')
-# 'base_name' is optional. Needed only if the same viewset is registered more than once
+domains_router.register(r'nameservers', NameserverViewSet, basename='domain-nameservers')
+# 'basename' is optional. Needed only if the same viewset is registered more than once
 # Official DRF docs on this option: http://www.django-rest-framework.org/api-guide/routers/
 
 urlpatterns = patterns('',
@@ -155,13 +155,13 @@ Example of nested router 3 levels deep.  You can use this same logic to nest rou
 ```python
 # urls.py
 router = DefaultRouter()
-router.register(r'clients', ClientViewSet, base_name='clients')
+router.register(r'clients', ClientViewSet, basename='clients')
 
 client_router = routers.NestedSimpleRouter(router, r'clients', lookup='client')
-client_router.register(r'maildrops', MailDropViewSet, base_name='maildrops')
+client_router.register(r'maildrops', MailDropViewSet, basename='maildrops')
 
 maildrops_router = routers.NestedSimpleRouter(client_router, r'maildrops', lookup='maildrop')
-maildrops_router.register(r'recipients', MailRecipientViewSet, base_name='recipients')
+maildrops_router.register(r'recipients', MailRecipientViewSet, basename='recipients')
 
 urlpatterns = patterns (
     '',

--- a/tests/serializers/urls.py
+++ b/tests/serializers/urls.py
@@ -5,17 +5,17 @@ from tests.serializers.models import Parent1Viewset, Child1Viewset, Parent2Views
 
 
 router_1 = routers.SimpleRouter()
-router_1.register('parent1', Parent1Viewset, base_name='parent1')
+router_1.register('parent1', Parent1Viewset, basename='parent1')
 parent_1_router = routers.NestedSimpleRouter(router_1, r'parent1', lookup='parent')
-parent_1_router.register(r'child1', Child1Viewset, base_name='child1')
+parent_1_router.register(r'child1', Child1Viewset, basename='child1')
 
 router_2 = routers.SimpleRouter()
-router_2.register('parent2', Parent2Viewset, base_name='parent2')
+router_2.register('parent2', Parent2Viewset, basename='parent2')
 parent_2_router = routers.NestedSimpleRouter(router_2, r'parent2', lookup='root')
-parent_2_router.register(r'child2', Child2Viewset, base_name='child2')
+parent_2_router.register(r'child2', Child2Viewset, basename='child2')
 
 parent_2_grandchild_router = routers.NestedSimpleRouter(parent_2_router, r'child2', lookup='parent')
-parent_2_grandchild_router.register(r'grandchild1', ParentChild2GrandChild1Viewset, base_name='grandchild1')
+parent_2_grandchild_router.register(r'grandchild1', ParentChild2GrandChild1Viewset, basename='grandchild1')
 
 urlpatterns = [
     url(r'^', include(router_1.urls)),

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -108,12 +108,12 @@ class TestEmptyPrefix(TestCase):
 class TestBadLookupValue(TestCase):
     def setUp(self):
         self.router = SimpleRouter()
-        self.router.register(r'parents', AViewSet, base_name='ui-parent_1')
+        self.router.register(r'parents', AViewSet, basename='ui-parent_1')
 
     def test_bad_lookup(self):
         with self.assertRaises(ValueError):
             self.a_router = NestedSimpleRouter(self.router, r'parents', lookup='ui-parent_2')
-            self.a_router.register(r'child', BViewSet, base_name='ui-parent-child')
+            self.a_router.register(r'child', BViewSet, basename='ui-parent-child')
 
 
 class TestRouterSettingInheritance(TestCase):

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -59,10 +59,11 @@ class ChildWithNestedMixinViewSet(NestedViewSetMixin, ModelViewSet):
 
 
 router = SimpleRouter()
-router.register('root', RootViewSet, base_name='root')
+print(router.register)
+router.register('root', RootViewSet, basename='root')
 root_router = NestedSimpleRouter(router, r'root', lookup='parent')
-root_router.register(r'child', ChildViewSet, base_name='child')
-root_router.register(r'child-with-nested-mixin', ChildWithNestedMixinViewSet, base_name='child-with-nested-mixin')
+root_router.register(r'child', ChildViewSet, basename='child')
+root_router.register(r'child-with-nested-mixin', ChildWithNestedMixinViewSet, basename='child-with-nested-mixin')
 
 
 urlpatterns = [


### PR DESCRIPTION
In commit 7095021db7a3e2a905979c17f5af8fce614edeb9, django-rest-framework
changed the router.register base_name variable name to  basename.
This commit fixes the variable name so that the documentation and code is
coherent with the upstream library.

PS: I don't really know how to change tox.ini config to make the tests pass.

Thanks and have a nice day !