### PR TITLE
CI will run only for DRF 3.11+, Django LTS+ and non-EOL Pythons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   # Allows you to run this workflow manually from the Actions tab
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5


### PR DESCRIPTION
Goodbye Python 2.7
Goodbye Django 1.11