### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ You can install this library using pip:
 
 ```pip install drf-nested-routers```
 
+In your Django project's settings.py file, add the following in INSTALLED_APPS:
+
+```'rest_framework_nested',```
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ You can install this library using pip:
 
 ```pip install drf-nested-routers```
 
-In your Django project's settings.py file, add the following in INSTALLED_APPS:
-
-```'rest_framework_nested',```
+Is not needed to add this library in your Django project's settings.py file, as it does not contain any app, signal or model.
 
 ## Quickstart
 


### PR DESCRIPTION
Updated README to add instruction for updating settings.py in Django project with the package name, the reason to add this is as follows:
- Developer often forget to add app name in settings.py file until they encounter related error.
- Also developer can assume that the name that  needed to be added in INSTALLED_APPS is drf-nested-routers since this is what we use when using pip install, but the app name to be added in INSTALLED_APPS is 'rest_framework_nested',
@alanjds please review and approve my PR, thanks.