### PR TITLE
fix: Replace misplaced lookup names

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This example ahead accomplishes the below URL patterns.
 /clients/
 /clients/{pk}/
 /clients/{client_pk}/maildrops/
-/clients/{client_pk}/maildrops/{maildrop_pk}/
+/clients/{client_pk}/maildrops/{pk}/
 /clients/{client_pk}/maildrops/{maildrop_pk}/recipients/
 /clients/{client_pk}/maildrops/{maildrop_pk}/recipients/{pk}/
 ```
@@ -181,7 +181,7 @@ client_router = routers.NestedSimpleRouter(router, r'clients', lookup='client')
 client_router.register(r'maildrops', MailDropViewSet, basename='maildrops')
 ## generates:
 # /clients/{client_pk}/maildrops/
-# /clients/{client_pk}/maildrops/{maildrop_pk}/
+# /clients/{client_pk}/maildrops/{pk}/
 
 maildrops_router = routers.NestedSimpleRouter(client_router, r'maildrops', lookup='maildrop')
 maildrops_router.register(r'recipients', MailRecipientViewSet, basename='recipients')


### PR DESCRIPTION
Hey, Alan! Congratulations for you excelente work, this lib is great.

I'm pull requesting because of this mistake, if I got it right, in the Infinite depth example.

You should have used `pk` instead of `maildrop_pk` in the covered patterns of `client_router` .

If I'm wrong about it, sorry for your time. But I had the best of the intentions.