### PR TITLE
Update CI over new and deprecated Python/Django/DRF versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11 rc"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11 rc"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11 rc"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "${{ matrix.python-version }}"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11 rc"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11-dev"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ exist without a domain, so you need it "nested" inside the domain.
 
 ## Requirements & Compatibility
 
--  Python (3.6, 3.7, 3.8, 3.9)
--  Django (2.2, 3.0, 3.1)
--  Django REST Framework (3.11)
+-  Python (3.7, 3.8, 3.9, 3.10, 3.11)
+-  Django (2.2, 3.0, 3.1, 3.2, 4.0)
+-  Django REST Framework (3.11, 3.12, 3.13)
 
 It may work with lower versions, but since the release **0.92.1** is no more
 tested on CI for Pythons 2.7 to 3.5, Django 1.11 to 2.1 or DRF 3.6 to 3.10.
+And since **0.93.5** is no more tested on CI for Python 3.6.
 
 
 ## Installation

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -10,5 +10,6 @@ pytz==2022.2.1
 wheel==0.37.1
 
 # MkDocs for documentation previews/deploys
-mkdocs==1.2.4
-markdown==3.2.1
+mkdocs==1.2.4; python_version < '3.8'
+markdown==3.2.1; python_version < '3.8'
+mkdocs==1.4.1; python_version >= '3.8'

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -1,7 +1,7 @@
 # Test requirements
-pytest==6.2.4
+pytest==7.1.2
 pytest-cov==2.12.1
-pytest-django==4.2.0
+pytest-django==4.5.2
 flake8==3.9.2
 ipdb==0.13.9
 

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -4,6 +4,7 @@ pytest-cov==2.12.1
 pytest-django==4.5.2
 flake8==3.9.2
 ipdb==0.13.9
+pytz==2022.2.1
 
 # wheel for PyPI installs
 wheel==0.37.0

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -1,8 +1,8 @@
 # Test requirements
-pytest==7.1.2
+pytest==7.1.3
 pytest-cov==3.0.0
 pytest-django==4.5.2
-flake8==4.0.1
+flake8==5.0.4
 ipdb==0.13.9
 pytz==2022.2.1
 
@@ -10,4 +10,5 @@ pytz==2022.2.1
 wheel==0.37.1
 
 # MkDocs for documentation previews/deploys
-mkdocs>=1.3.1
+mkdocs==1.2.4
+markdown==3.2.1

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -9,4 +9,4 @@ ipdb==0.13.9
 wheel==0.37.0
 
 # MkDocs for documentation previews/deploys
-mkdocs==1.2.2
+mkdocs==1.3.1

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -2,7 +2,7 @@
 pytest==7.1.2
 pytest-cov==2.12.1
 pytest-django==4.5.2
-flake8==3.9.2
+flake8>=3.9.2
 ipdb==0.13.9
 pytz==2022.2.1
 
@@ -10,4 +10,4 @@ pytz==2022.2.1
 wheel==0.37.0
 
 # MkDocs for documentation previews/deploys
-mkdocs==1.3.1
+mkdocs>=1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 -r requirements-tox.txt
 
 # Minimum Django and REST framework version
-Django>=1.11
-djangorestframework>=3.6.0
+Django>=2.2
+djangorestframework>=3.11.0
 

--- a/rest_framework_nested/__init__.py
+++ b/rest_framework_nested/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.93.3'
+__version__ = '0.93.4'

--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -14,15 +14,15 @@ Example:
     domains_router.register(r'nameservers', NameserverViewSet)
 
     url_patterns = patterns('',
-        url(r'^', include(router.urls)),
-            url(r'^', include(domains_router.urls)),
-            )
+        path('', include(router.urls)),
+        path('', include(domains_router.urls)),
+    )
 
-        router = routers.DefaultRouter()
-        router.register('users', UserViewSet, 'user')
-        router.register('accounts', AccountViewSet, 'account')
+    router = routers.DefaultRouter()
+    router.register('users', UserViewSet, 'user')
+    router.register('accounts', AccountViewSet, 'account')
 
-        urlpatterns = router.urls
+    urlpatterns = router.urls
 """
 
 from __future__ import unicode_literals

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.93.3
+current_version = 0.93.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,8 @@ setup(
     packages=get_packages(package),
     package_data=get_package_data(package),
     install_requires=[
-        'djangorestframework>=3.6.0',
-        'Django>=1.11',
+        'djangorestframework>=3.11.0',
+        'Django>=2.2',
     ],
     python_requires=">=3.5",
     classifiers=[

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
 
@@ -34,7 +33,7 @@ class Anchor(RESTFrameworkModel):
 
 
 class BasicModel(RESTFrameworkModel):
-    text = models.CharField(max_length=100, verbose_name=_("Text comes here"), help_text=_("Text description."))
+    text = models.CharField(max_length=100, verbose_name="Text comes here", help_text="Text description.")
 
 
 class SlugBasedModel(RESTFrameworkModel):

--- a/tests/serializers/urls.py
+++ b/tests/serializers/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import include, path
 from rest_framework_nested import routers
 
 from tests.serializers.models import Parent1Viewset, Child1Viewset, Parent2Viewset, Child2Viewset, ParentChild2GrandChild1Viewset
@@ -18,9 +18,9 @@ parent_2_grandchild_router = routers.NestedSimpleRouter(parent_2_router, r'child
 parent_2_grandchild_router.register(r'grandchild1', ParentChild2GrandChild1Viewset, basename='grandchild1')
 
 urlpatterns = [
-    url(r'^', include(router_1.urls)),
-    url(r'^', include(parent_1_router.urls)),
-    url(r'^', include(router_2.urls)),
-    url(r'^', include(parent_2_router.urls)),
-    url(r'^', include(parent_2_grandchild_router.urls)),
+    path('', include(router_1.urls)),
+    path('', include(parent_1_router.urls)),
+    path('', include(router_2.urls)),
+    path('', include(parent_2_router.urls)),
+    path('', include(parent_2_grandchild_router.urls)),
 ]

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1,6 +1,6 @@
 import json
 
-from django.conf.urls import path, include
+from django.urls import path, include
 from django.db import models
 from django.test import TestCase, override_settings, RequestFactory
 from django.core.exceptions import ImproperlyConfigured

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1,6 +1,6 @@
 import json
 
-from django.conf.urls import url, include
+from django.conf.urls import path, include
 from django.db import models
 from django.test import TestCase, override_settings, RequestFactory
 from django.core.exceptions import ImproperlyConfigured
@@ -89,8 +89,8 @@ root_router.register(r'child-with-nested-mixin-not-defined', ChildWithNestedMixi
 
 
 urlpatterns = [
-    url(r'^', include(router.urls)),
-    url(r'^', include(root_router.urls)),
+    path('', include(router.urls)),
+    path('', include(root_router.urls)),
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py36,py37,py38,py39}-django{2.2,3.0,3.1}-drf{3.11}
+       {py36,py37,py38,py39}-django{2.2,3.0,3.1,3.2}-drf{3.11,3.12}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,12 @@ deps =
        drf3.13: djangorestframework>=3.13,<3.14
        -rrequirements-tox.txt
 
-[testenv:py27-flake8]
+[testenv:py39-flake8]
 commands = ./runtests.py --lintonly
 deps =
        -rrequirements-tox.txt
 
-[testenv:py27-docs]
+[testenv:py39-docs]
 commands = mkdocs build
 deps =
-       mkdocs>=0.11.1
+       mkdocs>=1.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py36,py37,py38,py39,py310}-django{2.2,3.0,3.1,3.2,4.0}-drf{3.11,3.12,3.13}
+       {py36,py37,py38,py39,py310,py311}-django{2.2,3.0,3.1,3.2,4.0}-drf{3.11,3.12,3.13}
 
 [gh-actions]
 python =
@@ -9,6 +9,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 commands = ./runtests.py --nolint

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        {py36,py37,py38,py39,py310,py311}-django{2.2,3.0,3.1,3.2}-drf{3.11,3.12,3.13}
-       {py38,py39,py310,py311}-django{4.0}-drf{3.11,3.12,3.13}
+       {py38,py39,py310,py311}-django{4.0}-drf{3.12,3.13}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py36,py37,py38,py39}-django{2.2,3.0,3.1,3.2}-drf{3.11,3.12}
+       {py36,py37,py38,py39,py310}-django{2.2,3.0,3.1,3.2,4.0}-drf{3.11,3.12,3.13}
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 commands = ./runtests.py --nolint
@@ -18,8 +19,10 @@ deps =
        django3.0: Django>=3.0,<3.1
        django3.1: Django>=3.1,<3.2
        django3.2: Django>=3.2,<3.3
+       django4.0: Django>=4.0,<4.1
        drf3.11: djangorestframework>=3.11,<3.12
        drf3.12: djangorestframework>=3.12,<3.13
+       drf3.13: djangorestframework>=3.13,<3.14
        -rrequirements-tox.txt
 
 [testenv:py27-flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-       {py36,py37,py38,py39,py310,py311}-django{2.2,3.0,3.1,3.2,4.0}-drf{3.11,3.12,3.13}
+       {py36,py37,py38,py39,py310,py311}-django{2.2,3.0,3.1,3.2}-drf{3.11,3.12,3.13}
+       {py38,py39,py310,py311}-django{4.0}-drf{3.11,3.12,3.13}
 
 [gh-actions]
 python =


### PR DESCRIPTION
Answering the issue #263, the CI now tests up to Django 4 using the compatible interpreters up to Python 3.11

The support for Python 3.6 is now officially dropped, as it have reached its EOL. 