### PR TITLE
add swagger check to NestedViewSetMixin

### DIFF
--- a/rest_framework_nested/viewsets.py
+++ b/rest_framework_nested/viewsets.py
@@ -60,6 +60,9 @@ class NestedViewSetMixin(object):
         Adds the parent params from URL inside the children data available
         """
         request = super().initialize_request(request, *args, **kwargs)
+        
+        if getattr(self, 'swagger_fake_view', False):
+            return request
 
         for url_kwarg, fk_filter in self._get_parent_lookup_kwargs().items():
             # fk_filter is alike 'grandparent__parent__pk'

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ python =
 
 [testenv]
 commands = ./runtests.py --nolint
+allowlist_externals = ['./runtests.py ']
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
 
 [testenv]
 commands = ./runtests.py --nolint
-allowlist_externals = ['./runtests.py ']
+allowlist_externals=*
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
 
 [testenv]
 commands = ./runtests.py --nolint
-allowlist_externals=*
+allowlist_externals = *
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =


### PR DESCRIPTION
A check for `swagger_fake_view` is done in the `get_queryset` function of the `NestedViewSetMixin`.  
However this needs to be added to `initialize_request` for a schema to be generated by a request.

I was getting errors when using the `drf_spectacular` package to serve the schema at `/schema`  
Adding this check to the `initialize_request` fixed this issue.

I don't know if this package is still maintained. Let me know if this is not going to be considered.

This package is awesome btw.  
Thanks so much!