### PR TITLE
Mark package as including typehints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def get_package_data(package):
             for dirpath, dirnames, filenames in os.walk(package)
             if not os.path.exists(os.path.join(dirpath, '__init__.py'))]
 
-    filepaths = []
+    filepaths = ['py.typed']
     for base, filenames in walk:
         filepaths.extend([os.path.join(base, filename)
                           for filename in filenames])


### PR DESCRIPTION
PEP 561 requires typehinted projects to include a `py.typed` file, for typecheckers to recognize the hints.

https://peps.python.org/pep-0561/#packaging-type-information