### PR TITLE
CI: Enable testing with Python 3.12, Django 5.0, DRF 3.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      max-parallel: 6
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
         echo
         env
     - name: Test with tox
-      run: tox run --skip-env=py311-mypy
+      run: tox run --skip-env=py312-mypy
 
   mypy:
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -54,4 +54,4 @@ jobs:
         echo
         env
     - name: Test with tox
-      run: tox run -e py311-mypy
+      run: tox run -e py312-mypy

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ exist without a domain, so you need it "nested" inside the domain.
 
 ## Requirements & Compatibility
 
--  Python (3.8, 3.9, 3.10, 3.11, 3.12)
--  Django (4.2, 5.0)
--  Django REST Framework (3.14, 3.15)
+- Python (3.8, 3.9, 3.10, 3.11, 3.12)
+- Django (4.2, 5.0)
+- Django REST Framework (3.14, 3.15)
 
 It may work with lower versions, but since the release **0.93.5** is no more tested on CI for Python 3.6 or lower.<br/>
 And since **0.92.1** is no more tested on CI for Pythons 2.7 to 3.5, Django 1.11 to 2.1 or DRF 3.6 to 3.10.<br/>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ exist without a domain, so you need it "nested" inside the domain.
 
 ## Requirements & Compatibility
 
--  Python (3.8, 3.9, 3.10, 3.11)
--  Django (3.2, 4.1, 4.2)
--  Django REST Framework (3.14)
+-  Python (3.8, 3.9, 3.10, 3.11, 3.12)
+-  Django (4.2, 5.0)
+-  Django REST Framework (3.14, 3.15)
 
 It may work with lower versions, but since the release **0.93.5** is no more tested on CI for Python 3.6 or lower.<br/>
 And since **0.92.1** is no more tested on CI for Pythons 2.7 to 3.5, Django 1.11 to 2.1 or DRF 3.6 to 3.10.<br/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ Nested resources for the Django Rest Framework
 
 ## Requirements
 
-* Python (3.8, 3.9, 3.10, 3.11)
-* Django (3.2, 4.1, 4.2)
+* Python (3.8, 3.9, 3.10, 3.11, 3.12)
+* Django (3.2, 4.1, 4.2, 5.0)
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,9 @@ Nested resources for the Django Rest Framework
 
 ## Requirements
 
-* Python (3.8, 3.9, 3.10, 3.11, 3.12)
-* Django (3.2, 4.1, 4.2, 5.0)
+- Python (3.8, 3.9, 3.10, 3.11, 3.12)
+- Django (4.2, 5.0)
+- Django REST Framework (3.14, 3.15)
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 -r requirements-tox.txt
 
 # Minimum Django and REST framework version
-Django>=3.2
+Django>=4.2
 djangorestframework>=3.14.0
 

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
@@ -96,6 +97,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -77,15 +77,13 @@ setup(
     package_data=get_package_data(package),
     install_requires=[
         'djangorestframework>=3.14.0',
-        'Django>=3.2',
+        'Django>=4.2',
     ],
     python_requires=">=3.8",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-       py{38,39,310,311,312}-django{3.2,4.1,4.2}-drf{3.14,3.15}
-       py{310,311,312}-django5.0-drf{3.14,3.15}
+       py{38,39,310,311,312,313}-django4.2-drf{3.14,3.15}
+       py{310,311,312,313}-django5.0-drf{3.14,3.15}
        py312-mypy
 
 [gh-actions]
@@ -11,6 +11,7 @@ python =
        3.10: py310
        3.11: py311
        3.12: py312
+       3.13: py313
 
 [testenv]
 commands = ./runtests.py --nolint
@@ -18,8 +19,6 @@ allowlist_externals = *
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django3.2: Django>=3.2,<3.3
-       django4.1: Django>=4.1,<4.2
        django4.2: Django>=4.2,<4.3
        django5.0: Django>=5.0,<5.1
        drf3.14: djangorestframework>=3.14,<3.15

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-       py{38,39,310,311}-django{3.2,4.1,4.2}-drf3.14
-       py311-mypy
+       py{38,39,310,311,312}-django{3.2,4.1,4.2}-drf{3.14,3.15}
+       py{310,311,312}-django5.0-drf{3.14,3.15}
+       py312-mypy
 
 [gh-actions]
 python =
@@ -9,6 +10,7 @@ python =
        3.9: py39
        3.10: py310
        3.11: py311
+       3.12: py312
 
 [testenv]
 commands = ./runtests.py --nolint
@@ -19,20 +21,22 @@ deps =
        django3.2: Django>=3.2,<3.3
        django4.1: Django>=4.1,<4.2
        django4.2: Django>=4.2,<4.3
+       django5.0: Django>=5.0,<5.1
        drf3.14: djangorestframework>=3.14,<3.15
+       drf3.15: djangorestframework>=3.15,<3.16
        -rrequirements-tox.txt
 
-[testenv:py311-flake8]
+[testenv:py312-flake8]
 commands = ./runtests.py --lintonly
 deps =
        -rrequirements-tox.txt
 
-[testenv:py311-docs]
+[testenv:py312-docs]
 commands = mkdocs build
 deps =
        mkdocs>=1.3.0
 
-[testenv:py311-mypy]
+[testenv:py312-mypy]
 commands = mypy rest_framework_nested
 deps =
        -rrequirements-tox.txt


### PR DESCRIPTION
Adding many versions into the test matrix.

Should I also remove Python and Django versions that are EOL?
