### PR TITLE
Support For DRF 3.15 nested SimpleRouter.use_regex_path = False

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ exist without a domain, so you need it "nested" inside the domain.
 
 - Python (3.8, 3.9, 3.10, 3.11, 3.12)
 - Django (4.2, 5.0)
-- Django REST Framework (3.14, 3.15)
+- Django REST Framework (3.15)
 
 It may work with lower versions, but since the release **0.93.5** is no more tested on CI for Python 3.6 or lower.<br/>
 And since **0.92.1** is no more tested on CI for Pythons 2.7 to 3.5, Django 1.11 to 2.1 or DRF 3.6 to 3.10.<br/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 
 # Minimum Django and REST framework version
 Django>=4.2
-djangorestframework>=3.14.0
+djangorestframework>=3.15.0
 

--- a/rest_framework_nested/routers.py
+++ b/rest_framework_nested/routers.py
@@ -59,6 +59,7 @@ class NestedMixin:
         self.parent_prefix = parent_prefix
         self.nest_count = getattr(parent_router, 'nest_count', 0) + 1
         self.nest_prefix = kwargs.pop('lookup', f'nested_{self.nest_count}') + '_'
+        self.use_regex_path = kwargs.get('use_regex_path', True)
 
         super().__init__(*args, **kwargs)
 
@@ -111,7 +112,11 @@ class NestedMixin:
             # to escape it
             escaped_parent_regex = self.parent_regex.replace('{', '{{').replace('}', '}}')
 
-            route_contents['url'] = route.url.replace('^', '^' + escaped_parent_regex)
+            if self.use_regex_path:
+                route_contents['url'] = route.url.replace('^', '^' + escaped_parent_regex)
+            else:
+                route_contents['url'] = escaped_parent_regex + route_contents['url']
+
             nested_routes.append(type(route)(**route_contents))
 
         self.routes = nested_routes

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     packages=get_packages(package),
     package_data=get_package_data(package),
     install_requires=[
-        'djangorestframework>=3.14.0',
+        'djangorestframework>=3.15.0',
         'Django>=4.2',
     ],
     python_requires=">=3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-       py{38,39,310,311,312,313}-django4.2-drf{3.14,3.15}
-       py{310,311,312,313}-django5.0-drf{3.14,3.15}
+       py{38,39,310,311,312,313}-django4.2-drf3.15
+       py{310,311,312,313}-django5.0-drf3.15
        py312-mypy
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ setenv =
 deps =
        django4.2: Django>=4.2,<4.3
        django5.0: Django>=5.0,<5.1
-       drf3.14: djangorestframework>=3.14,<3.15
        drf3.15: djangorestframework>=3.15,<3.16
        -rrequirements-tox.txt
 


### PR DESCRIPTION
This PR is to address the following issue:
https://github.com/alanjds/drf-nested-routers/issues/342

In order to properly use use_regex_path=False for the simple router you must have DRF 3.15+. If the kwarg is passed and an earlier version of DRF is used it should simply TypeError due to the unexpected kwarg . If this requires a read-me update for notes around Requirements & Compatibility let me know what you would like to see there and I can add it.

The changes are the same as suggested in https://github.com/alanjds/drf-nested-routers/issues/342 and are explained in more detail there. The changes are essentially changing how we pre-pend the parent url when use_regex_path=False, allowing it to correctly nest the routes. I also added a unit test validating the changes.

Please let me know if you have any concerns or questions!