### PR TITLE
Test against Django 5.1 and update test import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "${{ matrix.python-version }}"
     - name: Install dependencies
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.12
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ exist without a domain, so you need it "nested" inside the domain.
 
 ## Requirements & Compatibility
 
-- Python (3.8, 3.9, 3.10, 3.11, 3.12)
-- Django (4.2, 5.0)
+- Python (3.8, 3.9, 3.10, 3.11, 3.12, 3.13)
+- Django (4.2, 5.0, 5.1)
 - Django REST Framework (3.14, 3.15)
 
 It may work with lower versions, but since the release **0.93.5** is no more tested on CI for Python 3.6 or lower.<br/>

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,4 +1,3 @@
-
 def get_regex_pattern(urlpattern):
     if hasattr(urlpattern, 'pattern'):
         # Django 2.0

--- a/tests/serializers/test_serializers.py
+++ b/tests/serializers/test_serializers.py
@@ -1,13 +1,9 @@
 import json
 import pytest
 from django.test import TestCase
+from django.urls import reverse
 
 from tests.serializers.models import Parent, Child1, Child2, GrandChild1
-
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
 
 
 class TestSerializers(TestCase):

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1,6 +1,6 @@
 import json
 
-from django.urls import path, include
+from django.urls import include, path, reverse
 from django.db import models
 from django.test import TestCase, override_settings, RequestFactory
 from django.core.exceptions import ImproperlyConfigured
@@ -14,11 +14,6 @@ from rest_framework.schemas import generators
 from rest_framework_nested.routers import NestedSimpleRouter
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
 from rest_framework_nested.viewsets import NestedViewSetMixin
-
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
 
 factory = RequestFactory()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
+# see https://docs.djangoproject.com/en/5.1/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-       py{38,39,310,311,312,313}-django4.2-drf{3.14,3.15}
-       py{310,311,312,313}-django5.0-drf{3.14,3.15}
+       py{38,39,310,311,312}-django4.2-drf{3.14,3.15}
+       py{310,311,312}-django5.0-drf{3.14,3.15}
+       py{310,311,312,313}-django5.1-drf{3.14,3.15}
        py312-mypy
 
 [gh-actions]
@@ -21,6 +23,7 @@ setenv =
 deps =
        django4.2: Django>=4.2,<4.3
        django5.0: Django>=5.0,<5.1
+       django5.1: Django>=5.1,<5.2
        drf3.14: djangorestframework>=3.14,<3.15
        drf3.15: djangorestframework>=3.15,<3.16
        -rrequirements-tox.txt


### PR DESCRIPTION
- Tests against Django 5.1 and only test against supported Python versions
- Updates GitHub actions to fix deprecation warnings
- Update tests to just use `from django.urls import reverse()` instead of `from django.core.urlresolvers import reverse`. This was changed in Django 1.10.