### PR TITLE
change the lifecycle hook where parent_kwargs are injected in the request data

### DIFF
--- a/rest_framework_nested/viewsets.py
+++ b/rest_framework_nested/viewsets.py
@@ -64,19 +64,19 @@ class NestedViewSetMixin(Generic[T_Model]):
             orm_filters[field_name] = self.kwargs[query_param]  # type: ignore[attr-defined]
         return queryset.filter(**orm_filters)
 
-    def initialize_request(self, request: HttpRequest, *args: Any, **kwargs: Any) -> Request:
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         """
         Adds the parent params from URL inside the children data available
         """
-        drf_request: Request = super().initialize_request(request, *args, **kwargs)  # type: ignore[misc]
+        # run all the DRF API policies first
+        super().initial(request, *args, **kwargs)  # type: ignore[misc]
 
         if getattr(self, 'swagger_fake_view', False):
-            return drf_request
+            return
 
         for url_kwarg, fk_filter in self._get_parent_lookup_kwargs().items():
             # fk_filter is alike 'grandparent__parent__pk'
             parent_arg = fk_filter.partition('__')[0]
-            for querydict in [drf_request.data, drf_request.query_params]:
+            for querydict in [request.data, request.query_params]:
                 with _force_mutable(querydict):
                     querydict[parent_arg] = kwargs[url_kwarg]
-        return drf_request

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1,15 +1,15 @@
 import json
 
-from django.urls import include, path, reverse
-from django.db import models
-from django.test import TestCase, override_settings, RequestFactory
 from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import include, path, reverse
 from rest_framework import status
+from rest_framework.reverse import reverse as drf_reverse
 from rest_framework.routers import SimpleRouter
+from rest_framework.schemas import generators
 from rest_framework.serializers import HyperlinkedModelSerializer, ModelSerializer
 from rest_framework.viewsets import ModelViewSet
-from rest_framework.reverse import reverse as drf_reverse
-from rest_framework.schemas import generators
 
 from rest_framework_nested.routers import NestedSimpleRouter
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
@@ -216,3 +216,32 @@ class TestNestedSimpleRouter(TestCase):
             setattr(view, 'swagger_fake_view', True)
             # no error message should be raised here
             view.get_queryset()
+
+    def test_create_invalid_data_with_mixin(self):
+        """
+        The `NestedViewSetMixin` automatically sets the
+        parent kwarg on the request.{data,query_params} querydict.
+
+        This happens in the `initialize_request()` lifecycle method, but
+        this method is outside the DRF exception handler's scope, so
+        when the `request.data` is accessed, if the data is invalid, then
+        the exception will not be handled by DRF, and it will result in a 500.
+
+        If we handle that after the `initial()` method, which checks all
+        the API policies, like content negotiation, throttling, permisisons, etc, then
+        the invalid data will be caught by the content negotiation and an appropiate
+        HTTP 400 error should be received by the client.
+        """
+        resource_url = reverse(
+            "child-with-nested-mixin-list", kwargs={"parent_pk": self.root_1.pk}
+        )
+
+        response = self.client.post(
+            resource_url, content_type="application/json", data="invalid json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {"detail": "JSON parse error - Expecting value: line 1 column 1 (char 0)"},
+        )


### PR DESCRIPTION
The `NestedViewSetMixin` is trying to access `request.data` too early in the DRF lifecycle, and posting invalid JSON results in 500 errors.

The `initialize_request()` method is also run outside the DRF exception handler scope. I think a more appropriate place to inject the `parent_kwargs` in the request data and query params is _after_ the `initial()` phase of the request lifecycle, just before the request method(get/post etc) handler starts.

This way, we can be sure that the API policy defined for content negotiation, authentication, permisisons and throttles is run properly.