### PR TITLE
Allow using NestedHyperlinkedRelatedField without a model-related field

### DIFF
--- a/rest_framework_nested/relations.py
+++ b/rest_framework_nested/relations.py
@@ -56,8 +56,12 @@ class NestedHyperlinkedRelatedField(HyperlinkedRelatedField, Generic[T_Model]):
                 # use the Django ORM to lookup this value, e.g., obj.parent.pk
                 lookup_value = reduce(getattr, [obj] + lookups)  # type: ignore[operator,arg-type]
             except AttributeError:
-                # Not nested. Act like a standard HyperlinkedRelatedField
-                return super().get_url(obj, view_name, request, format)
+                # look for the field in the view, allowing to use this without a field relation
+                try:
+                    lookup_value = getattr(self.root.context["view"], underscored_lookup)
+                except (AttributeError, ObjectDoesNotExist):
+                    # Not nested. Act like a standard HyperlinkedRelatedField
+                    return super().get_url(obj, view_name, request, format)
 
             # store the lookup_name and value in kwargs, which is later passed to the reverse method
             kwargs.update({parent_lookup_kwarg: lookup_value})


### PR DESCRIPTION
With this small change we can use the NestedHyperlinkedRelatedField with models that doesn't has a relation field between them. I don't know how to create a test demonstrating the use case; any help is welcome.

For example, in this case:

```python
class Item:
  name = models.CharField(max_length=10)

class Doc:
  name = models.CharField(max_length=10)

class Attachment:
  item = models.ForeignKey(Item, on_delete=models.CASCADE)
  doc =  models.ForeignKey(Item, on_delete=models.CASCADE)
```

If we want to have an URL like `/item/1/doc/123`, we can do that with:
```python
class ItemDocumentsViewSet(
    mixins.ListModelMixin,
    mixins.CreateModelMixin,
    mixins.DestroyModelMixin,
    viewsets.GenericViewSet,
):
    serializer_class = ItemDocumentSerializer

    def __init__(self, **kwargs):
        self.item_id = None
        super().__init__(**kwargs)

    def initialize_request(self, request, *args, **kwargs):
        request = super().initialize_request(request, *args, **kwargs)
        self.item_id = kwargs.get("item_id")
        return request

   # ....

class ItemDocumentSerializer(HyperlinkedModelSerializer):
    url = NestedHyperlinkedIdentityField(
        view_name="item-documents-detail",
        lookup_url_kwarg="id",
        parent_lookup_kwargs={"item_id": "item_id"},
    )
    
    class Meta:
        model = Doc
        fields = ("url", "name")
    
```
