### PR TITLE
Drop support for Python 3.8 (EOL)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Nested resources for the Django Rest Framework
 
 ## Requirements
 
-- Python (3.8, 3.9, 3.10, 3.11, 3.12)
+- Python (3.9, 3.10, 3.11, 3.12)
 - Django (4.2, 5.0, 5.1, 5.2)
 - Django REST Framework (3.14, 3.15, 3.16)
 

--- a/rest_framework_nested/viewsets.py
+++ b/rest_framework_nested/viewsets.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Any, Generic, Iterator, TypeVar
+from typing import Any, Generic, TypeVar
+from collections.abc import Iterator
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model, QuerySet

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'djangorestframework>=3.15.0',
         'Django>=4.2',
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -93,7 +93,6 @@ setup(
         'Operating System :: OS Independent',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
https://endoflife.date/python

Coming from https://github.com/alanjds/drf-nested-routers/pull/384#issuecomment-3271243006

> Python EOLed versions, sure, always.